### PR TITLE
User get with children

### DIFF
--- a/src/main/java/com/knotslicer/server/adapters/jpa/EventDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/EventDaoImpl.java
@@ -27,14 +27,14 @@ public class EventDaoImpl implements ChildWithOneRequiredParentDao<Event, User> 
         userImpl.addEvent((EventImpl) event);
         userImpl = entityManager.merge(userImpl);
         entityManager.flush();
-        event = getEventFromUser(userImpl, event);
-        entityManager.refresh(event);
-        return event;
+        return getEventFromUser(
+                userImpl,
+                event);
     }
     private UserImpl getUserWithEventsFromJpa(Long userId) {
         TypedQuery<UserImpl> query = entityManager.createQuery
                         ("SELECT user FROM User user " +
-                                "INNER JOIN FETCH user.events " +
+                                "LEFT JOIN FETCH user.events " +
                                 "WHERE user.userId = :userId", UserImpl.class)
                 .setParameter("userId", userId);
         return query.getSingleResult();
@@ -78,9 +78,9 @@ public class EventDaoImpl implements ChildWithOneRequiredParentDao<Event, User> 
         userImpl = entityManager
                 .merge(userImpl);
         entityManager.flush();
-        Event updatedEvent =
-                getEventFromUser(userImpl, eventToBeModified);
-        return updatedEvent;
+        return getEventFromUser(
+                userImpl,
+                eventToBeModified);
     }
 
     @Override

--- a/src/main/java/com/knotslicer/server/adapters/jpa/EventDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/EventDaoImpl.java
@@ -50,14 +50,13 @@ public class EventDaoImpl implements ChildWithOneRequiredParentDao<Event, User> 
         return Optional.ofNullable(event);
     }
     @Override
-    public Long getPrimaryParentId(Long eventId) {
-        TypedQuery<UserImpl> query = entityManager.createQuery
-                        ("SELECT user FROM User user " +
-                                "INNER JOIN user.events event " +
-                                "WHERE event.eventId = :eventId", UserImpl.class)
+    public User getPrimaryParent(Long eventId) {
+        TypedQuery<UserImpl> query = entityManager.createQuery(
+                "SELECT user FROM User user " +
+                        "INNER JOIN user.events event " +
+                        "WHERE event.eventId = :eventId", UserImpl.class)
                 .setParameter("eventId", eventId);
-        User user = query.getSingleResult();
-        return user.getUserId();
+        return query.getSingleResult();
     }
     @Override
     public Optional<User> getPrimaryParentWithChildren(Long userId) {
@@ -84,10 +83,14 @@ public class EventDaoImpl implements ChildWithOneRequiredParentDao<Event, User> 
     }
 
     @Override
-    public void delete(Long eventId, Long userId) {
-        UserImpl userImpl = getUserWithEventsFromJpa(userId);
-        EventImpl eventImpl = entityManager.find(EventImpl.class, eventId);
-        userImpl.removeEvent(eventImpl);
+    public void delete(Long eventId) {
+        User user = getPrimaryParent(eventId);
+        UserImpl userWithEvents =
+                getUserWithEventsFromJpa(
+                        user.getUserId());
+        EventImpl eventImpl = entityManager
+                .find(EventImpl.class, eventId);
+        userWithEvents.removeEvent(eventImpl);
         entityManager.flush();
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
@@ -31,13 +31,12 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
         memberImpl = getMemberFromUser(userImpl, memberImpl);
         projectImpl.addMember(memberImpl);
         entityManager.flush();
-        //entityManager.refresh(memberImpl);
         return memberImpl;
     }
     private UserImpl getUserWithMembersFromJpa(Long userId) {
         TypedQuery<UserImpl> query = entityManager.createQuery
                         ("SELECT user FROM User user " +
-                                "INNER JOIN FETCH user.members " +
+                                "LEFT JOIN FETCH user.members " +
                                 "WHERE user.userId = :userId", UserImpl.class)
                 .setParameter("userId", userId);
         return query.getSingleResult();
@@ -45,7 +44,7 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
     private ProjectImpl getProjectWithMembersFromJpa(Long projectId) {
         TypedQuery<ProjectImpl> query = entityManager.createQuery
                         ("SELECT project FROM Project project " +
-                                "INNER JOIN FETCH project.members " +
+                                "LEFT JOIN FETCH project.members " +
                                 "WHERE project.projectId = :projectId", ProjectImpl.class)
                 .setParameter("projectId", projectId);
         return query.getSingleResult();
@@ -106,9 +105,9 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
                 memberInput.getRoleDescription());
         userImpl = entityManager.merge(userImpl);
         entityManager.flush();
-        Member updatedMember =
-                getMemberFromUser(userImpl, memberToBeModified);
-        return updatedMember;
+        return getMemberFromUser(
+                userImpl,
+                memberToBeModified);
     }
 
     @Override

--- a/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
@@ -31,7 +31,7 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
         memberImpl = getMemberFromUser(userImpl, memberImpl);
         projectImpl.addMember(memberImpl);
         entityManager.flush();
-        entityManager.refresh(memberImpl);
+        //entityManager.refresh(memberImpl);
         return memberImpl;
     }
     private UserImpl getUserWithMembersFromJpa(Long userId) {

--- a/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/MemberDaoImpl.java
@@ -70,24 +70,22 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
         return Optional.ofNullable(project);
     }
     @Override
-    public Long getPrimaryParentId(Long memberId) {
-        TypedQuery<UserImpl> query = entityManager.createQuery
-                        ("SELECT user FROM User user " +
-                                "INNER JOIN user.members m " +
-                                "WHERE m.memberId = :memberId", UserImpl.class)
+    public User getPrimaryParent(Long memberId) {
+        TypedQuery<UserImpl> query = entityManager.createQuery(
+                "SELECT user FROM User user " +
+                        "INNER JOIN user.members m " +
+                        "WHERE m.memberId = :memberId", UserImpl.class)
                 .setParameter("memberId", memberId);
-        User user = query.getSingleResult();
-        return user.getUserId();
+        return query.getSingleResult();
     }
     @Override
-    public Long getSecondaryParentId(Long memberId) {
-        TypedQuery<ProjectImpl> query = entityManager.createQuery
-                        ("SELECT project FROM Project project " +
-                                "INNER JOIN project.members m " +
-                                "WHERE m.memberId = :memberId", ProjectImpl.class)
+    public Project getSecondaryParent(Long memberId) {
+        TypedQuery<ProjectImpl> query = entityManager.createQuery(
+                "SELECT project FROM Project project " +
+                        "INNER JOIN project.members m " +
+                        "WHERE m.memberId = :memberId", ProjectImpl.class)
                 .setParameter("memberId", memberId);
-        Project project = query.getSingleResult();
-        return project.getProjectId();
+        return query.getSingleResult();
     }
     @Override
     public Member update(Member memberInput, Long userId) {
@@ -111,10 +109,14 @@ public class MemberDaoImpl implements ChildWithTwoParentsDao<Member,User,Project
     }
 
     @Override
-    public void delete(Long memberId, Long userId) {
-        UserImpl userImpl = getUserWithMembersFromJpa(userId);
-        MemberImpl memberImpl = entityManager.find(MemberImpl.class, memberId);
-        userImpl.removeMember(memberImpl);
+    public void delete(Long memberId) {
+        User user = getPrimaryParent(memberId);
+        UserImpl userWithMembers =
+                getUserWithMembersFromJpa(
+                        user.getUserId());
+        MemberImpl memberImpl = entityManager
+                .find(MemberImpl.class, memberId);
+        userWithMembers.removeMember(memberImpl);
         entityManager.flush();
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/jpa/PollAnswerDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/PollAnswerDaoImpl.java
@@ -31,13 +31,12 @@ public class PollAnswerDaoImpl implements ChildWithTwoParentsDao<PollAnswer,Poll
         pollAnswerImpl = getPollAnswerFromPoll(pollImpl, pollAnswerImpl);
         memberImpl.addPollAnswer(pollAnswerImpl);
         entityManager.flush();
-        entityManager.refresh(pollAnswerImpl);
         return pollAnswerImpl;
     }
     private PollImpl getPollWithPollAnswersFromJpa(Long pollId) {
         TypedQuery<PollImpl> query = entityManager.createQuery
                         ("SELECT poll FROM Poll poll " +
-                                "INNER JOIN FETCH poll.pollAnswers " +
+                                "LEFT JOIN FETCH poll.pollAnswers " +
                                 "WHERE poll.pollId = :pollId", PollImpl.class)
                 .setParameter("pollId", pollId);
         return query.getSingleResult();
@@ -45,7 +44,7 @@ public class PollAnswerDaoImpl implements ChildWithTwoParentsDao<PollAnswer,Poll
     private MemberImpl getMemberWithPollAnswersFromJpa(Long memberId) {
         TypedQuery<MemberImpl> query = entityManager.createQuery
                         ("SELECT m FROM Member m " +
-                                "INNER JOIN FETCH m.pollAnswers " +
+                                "LEFT JOIN FETCH m.pollAnswers " +
                                 "WHERE m.memberId = :memberId", MemberImpl.class)
                 .setParameter("memberId", memberId);
         return query.getSingleResult();
@@ -101,8 +100,9 @@ public class PollAnswerDaoImpl implements ChildWithTwoParentsDao<PollAnswer,Poll
         pollAnswerToBeModified.setApproved(pollAnswerInput.isApproved());
         pollImpl = entityManager.merge(pollImpl);
         entityManager.flush();
-        PollAnswer updatedPollAnswer = getPollAnswerFromPoll(pollImpl, pollAnswerToBeModified);
-        return updatedPollAnswer;
+        return getPollAnswerFromPoll(
+                pollImpl,
+                pollAnswerToBeModified);
     }
     @Override
     public void delete(Long pollAnswerId, Long pollId) {

--- a/src/main/java/com/knotslicer/server/adapters/jpa/PollDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/PollDaoImpl.java
@@ -50,14 +50,13 @@ public class PollDaoImpl implements ChildWithOneRequiredParentDao<Poll, Event> {
         return Optional.ofNullable(poll);
     }
     @Override
-    public Long getPrimaryParentId(Long pollId) {
-        TypedQuery<EventImpl> query = entityManager.createQuery
-                        ("SELECT event FROM Event event " +
-                                "INNER JOIN event.polls poll " +
-                                "WHERE poll.pollId = :pollId", EventImpl.class)
+    public Event getPrimaryParent(Long pollId) {
+        TypedQuery<EventImpl> query = entityManager.createQuery(
+                "SELECT event FROM Event event " +
+                        "INNER JOIN event.polls poll " +
+                        "WHERE poll.pollId = :pollId", EventImpl.class)
                 .setParameter("pollId", pollId);
-        Event event = query.getSingleResult();
-        return event.getEventId();
+        return query.getSingleResult();
     }
     @Override
     public Optional<Event> getPrimaryParentWithChildren(Long eventId) {
@@ -82,9 +81,13 @@ public class PollDaoImpl implements ChildWithOneRequiredParentDao<Poll, Event> {
     }
 
     @Override
-    public void delete(Long pollId, Long eventId) {
-        EventImpl eventImpl = getEventWithPollsFromJpa(eventId);
-        PollImpl pollImpl = entityManager.find(PollImpl.class, pollId);
+    public void delete(Long pollId) {
+        Event event = getPrimaryParent(pollId);
+        EventImpl eventImpl =
+                getEventWithPollsFromJpa(
+                        event.getEventId());
+        PollImpl pollImpl = entityManager
+                .find(PollImpl.class, pollId);
         eventImpl.removePoll(pollImpl);
         entityManager.flush();
     }

--- a/src/main/java/com/knotslicer/server/adapters/jpa/PollDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/PollDaoImpl.java
@@ -27,14 +27,14 @@ public class PollDaoImpl implements ChildWithOneRequiredParentDao<Poll, Event> {
         eventImpl.addPoll((PollImpl) poll);
         eventImpl = entityManager.merge(eventImpl);
         entityManager.flush();
-        poll = getPollFromEvent(eventImpl, poll);
-        entityManager.refresh(poll);
-        return poll;
+        return getPollFromEvent(
+                eventImpl,
+                poll);
     }
     private EventImpl getEventWithPollsFromJpa(Long eventId) {
         TypedQuery<EventImpl> query = entityManager.createQuery
                         ("SELECT event FROM Event event " +
-                                "INNER JOIN FETCH event.polls " +
+                                "LEFT JOIN FETCH event.polls " +
                                 "WHERE event.eventId = :eventId", EventImpl.class)
                 .setParameter("eventId", eventId);
         return query.getSingleResult();
@@ -76,8 +76,9 @@ public class PollDaoImpl implements ChildWithOneRequiredParentDao<Poll, Event> {
                 pollInput.getEndTimeUtc());
         eventImpl = entityManager.merge(eventImpl);
         entityManager.flush();
-        Poll updatedPoll = getPollFromEvent(eventImpl, pollToBeModified);
-        return updatedPoll;
+        return getPollFromEvent(
+                eventImpl,
+                pollToBeModified);
     }
 
     @Override

--- a/src/main/java/com/knotslicer/server/adapters/jpa/ProjectDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/ProjectDaoImpl.java
@@ -30,14 +30,14 @@ public class ProjectDaoImpl implements ChildWithOneRequiredParentDao<Project, Us
         userImpl.addProject((ProjectImpl) project);
         userImpl = entityManager.merge(userImpl);
         entityManager.flush();
-        project = getProjectFromUser(userImpl, project);
-        //entityManager.refresh(project);
-        return project;
+        return getProjectFromUser(
+                userImpl,
+                project);
     }
     private UserImpl getUserWithProjectsFromJpa(Long userId) {
         TypedQuery<UserImpl> query = entityManager.createQuery
                         ("SELECT user FROM User user " +
-                                "INNER JOIN FETCH user.projects " +
+                                "LEFT JOIN FETCH user.projects " +
                                 "WHERE user.userId = :userId", UserImpl.class)
                 .setParameter("userId", userId);
         return query.getSingleResult();
@@ -80,9 +80,9 @@ public class ProjectDaoImpl implements ChildWithOneRequiredParentDao<Project, Us
         userImpl = entityManager
                 .merge(userImpl);
         entityManager.flush();
-        Project updatedProject =
-                getProjectFromUser(userImpl, projectToBeModified);
-        return updatedProject;
+        return getProjectFromUser(
+                userImpl,
+                projectToBeModified);
     }
     @Override
     public void delete(Long projectId, Long userId) {

--- a/src/main/java/com/knotslicer/server/adapters/jpa/ProjectDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/ProjectDaoImpl.java
@@ -31,7 +31,7 @@ public class ProjectDaoImpl implements ChildWithOneRequiredParentDao<Project, Us
         userImpl = entityManager.merge(userImpl);
         entityManager.flush();
         project = getProjectFromUser(userImpl, project);
-        entityManager.refresh(project);
+        //entityManager.refresh(project);
         return project;
     }
     private UserImpl getUserWithProjectsFromJpa(Long userId) {

--- a/src/main/java/com/knotslicer/server/adapters/jpa/ScheduleDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/ScheduleDaoImpl.java
@@ -27,14 +27,14 @@ public class ScheduleDaoImpl implements ChildWithOneRequiredParentDao<Schedule, 
         memberImpl.addSchedule((ScheduleImpl) schedule);
         memberImpl = entityManager.merge(memberImpl);
         entityManager.flush();
-        schedule = getScheduleFromMember(memberImpl, schedule);
-        entityManager.refresh(schedule);
-        return schedule;
+        return getScheduleFromMember(
+                memberImpl,
+                schedule);
     }
     private MemberImpl getMemberWithSchedulesFromJpa(Long memberId) {
         TypedQuery<MemberImpl> query = entityManager.createQuery
                         ("SELECT m FROM Member m " +
-                                "INNER JOIN FETCH m.schedules " +
+                                "LEFT JOIN FETCH m.schedules " +
                                 "WHERE m.memberId = :memberId", MemberImpl.class)
                 .setParameter("memberId", memberId);
         return query.getSingleResult();
@@ -77,9 +77,9 @@ public class ScheduleDaoImpl implements ChildWithOneRequiredParentDao<Schedule, 
         memberImpl = entityManager
                 .merge(memberImpl);
         entityManager.flush();
-        Schedule updatedSchedule =
-                getScheduleFromMember(memberImpl, scheduleToBeModified);
-        return updatedSchedule;
+        return getScheduleFromMember(
+                memberImpl,
+                scheduleToBeModified);
     }
     @Override
     public void delete(Long scheduleId, Long memberId) {

--- a/src/main/java/com/knotslicer/server/adapters/jpa/UserDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/UserDaoImpl.java
@@ -21,7 +21,7 @@ public class UserDaoImpl implements UserDao {
     public User create(User user) {
         entityManager.persist(user);
         entityManager.flush();
-        entityManager.refresh(user);
+        //entityManager.refresh(user);
         return user;
     }
     @Override

--- a/src/main/java/com/knotslicer/server/adapters/jpa/UserDaoImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/jpa/UserDaoImpl.java
@@ -21,7 +21,6 @@ public class UserDaoImpl implements UserDao {
     public User create(User user) {
         entityManager.persist(user);
         entityManager.flush();
-        //entityManager.refresh(user);
         return user;
     }
     @Override

--- a/src/main/java/com/knotslicer/server/adapters/rest/UserWithChildrenResource.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/UserWithChildrenResource.java
@@ -1,0 +1,8 @@
+package com.knotslicer.server.adapters.rest;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+public interface UserWithChildrenResource {
+    Response getWithChildren(Long userId, UriInfo uriInfo);
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/UserWithEventsResource.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/UserWithEventsResource.java
@@ -6,7 +6,6 @@ import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkComman
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
-import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
 import com.knotslicer.server.ports.interactor.services.UserWithChildrenService;
 import jakarta.enterprise.context.RequestScoped;
@@ -22,10 +21,10 @@ import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URI;
 
-@Path("/users/{userId}/projects")
+@Path("/users/{userId}/events")
 @RequestScoped
-public class UserWithProjectsResource implements UserWithChildrenResource {
-    private UserWithChildrenService userWithProjectsService;
+public class UserWithEventsResource implements UserWithChildrenResource {
+    private UserWithChildrenService userWithEventsService;
     private LinkCreator<UserLightDto> linkCreator;
     private LinkReceiver linkReceiver;
     @GET
@@ -33,7 +32,7 @@ public class UserWithProjectsResource implements UserWithChildrenResource {
     @Override
     public Response getWithChildren(@PathParam("userId")Long userId, @Context UriInfo uriInfo) {
         UserLightDto userResponseDto =
-                userWithProjectsService
+                userWithEventsService
                         .getUserWithChildren(userId);
         LinkCommand<UserLightDto> linkCommand =
                 linkCreator.createLinkCommand(
@@ -52,14 +51,14 @@ public class UserWithProjectsResource implements UserWithChildrenResource {
         return invoker.executeCommand();
     }
     @Inject
-    public UserWithProjectsResource(@ProcessAs(ProcessType.PROJECT)
-                                    UserWithChildrenService userWithProjectsService,
-                                    @ProcessAs(ProcessType.PROJECT)
+    public UserWithEventsResource(@ProcessAs(ProcessType.EVENT)
+                                    UserWithChildrenService userWithEventsService,
+                                    @ProcessAs(ProcessType.EVENT)
                                     LinkCreator<UserLightDto> linkCreator,
                                     LinkReceiver linkReceiver){
-        this.userWithProjectsService = userWithProjectsService;
+        this.userWithEventsService = userWithEventsService;
         this.linkReceiver = linkReceiver;
         this.linkCreator = linkCreator;
     }
-    protected UserWithProjectsResource() {}
+    protected UserWithEventsResource() {}
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/UserWithMembersResource.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/UserWithMembersResource.java
@@ -21,18 +21,19 @@ import jakarta.ws.rs.core.UriInfo;
 
 import java.net.URI;
 
-@Path("/users/{userId}/projects")
+@Path("/users/{userId}/members")
 @RequestScoped
-public class UserWithProjectsResource implements UserWithChildrenResource {
-    private UserWithChildrenService userWithProjectsService;
+public class UserWithMembersResource implements UserWithChildrenResource {
+    private UserWithChildrenService userWithMembersService;
     private LinkCreator<UserLightDto> linkCreator;
     private LinkReceiver linkReceiver;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Override
     public Response getWithChildren(@PathParam("userId")Long userId, @Context UriInfo uriInfo) {
         UserLightDto userResponseDto =
-                userWithProjectsService
+                userWithMembersService
                         .getUserWithChildren(userId);
         LinkCommand<UserLightDto> linkCommand =
                 linkCreator.createLinkCommand(
@@ -51,14 +52,14 @@ public class UserWithProjectsResource implements UserWithChildrenResource {
         return invoker.executeCommand();
     }
     @Inject
-    public UserWithProjectsResource(@ProcessAs(ProcessType.PROJECT)
-                                    UserWithChildrenService userWithProjectsService,
-                                    @ProcessAs(ProcessType.PROJECT)
+    public UserWithMembersResource (@ProcessAs(ProcessType.MEMBER)
+                                        UserWithChildrenService userWithMembersService,
+                                    @ProcessAs(ProcessType.MEMBER)
                                     LinkCreator<UserLightDto> linkCreator,
-                                    LinkReceiver linkReceiver){
-        this.userWithProjectsService = userWithProjectsService;
-        this.linkReceiver = linkReceiver;
+                                    LinkReceiver linkReceiver) {
+        this.userWithMembersService = userWithMembersService;
         this.linkCreator = linkCreator;
+        this.linkReceiver = linkReceiver;
     }
-    protected UserWithProjectsResource() {}
+    protected UserWithMembersResource() {}
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/UserWithProjectsResource.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/UserWithProjectsResource.java
@@ -1,0 +1,33 @@
+package com.knotslicer.server.adapters.rest;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.ports.interactor.services.UserWithChildrenService;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+@Path("/users/{userId}/projects")
+@RequestScoped
+public class UserWithProjectsResource implements UserWithChildrenResource {
+    private LinkReceiver linkReceiver;
+    private UserWithChildrenService userWithChildrenService;
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Override
+    public Response getWithChildren(@PathParam("userId")Long userId, @Context UriInfo uriInfo) {
+
+        return null;
+    }
+    public UserWithProjectsResource(UserWithChildrenService userWithChildrenService,
+                                    LinkReceiver linkReceiver){
+        this.userWithChildrenService = userWithChildrenService;
+        this.linkReceiver = linkReceiver;
+    }
+    protected UserWithProjectsResource() {}
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/EventLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/EventLinkCommand.java
@@ -2,9 +2,7 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.EventDto;
-import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 
 public class EventLinkCommand extends LinkCommand<EventDto> {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/EventWithPollsLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/EventWithPollsLinkCommand.java
@@ -4,7 +4,6 @@ import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.EventDto;
 import com.knotslicer.server.ports.interactor.datatransferobjects.PollDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 import java.util.List;
 

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/LinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/LinkCommand.java
@@ -2,7 +2,6 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 
 public abstract class LinkCommand<D> {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/MemberLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/MemberLinkCommand.java
@@ -3,10 +3,7 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 public class MemberLinkCommand extends LinkCommand<MemberDto> {
     public MemberLinkCommand(LinkReceiver linkReceiver, MemberDto memberDto, UriInfo uriInfo) {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollAnswerLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollAnswerLinkCommand.java
@@ -3,7 +3,6 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.PollAnswerDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 
 public class PollAnswerLinkCommand extends LinkCommand<PollAnswerDto> {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollLinkCommand.java
@@ -3,7 +3,6 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.PollDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 
 public class PollLinkCommand extends LinkCommand<PollDto> {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollWithPollAnswersLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/PollWithPollAnswersLinkCommand.java
@@ -3,9 +3,7 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.PollAnswerDto;
 import com.knotslicer.server.ports.interactor.datatransferobjects.PollDto;
-import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 import java.util.List;
 

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ProjectLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ProjectLinkCommand.java
@@ -3,10 +3,7 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ProjectLinkCommand extends LinkCommand<ProjectDto> {
     public ProjectLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ProjectWithMembersLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ProjectWithMembersLinkCommand.java
@@ -4,11 +4,8 @@ import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
 import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ProjectWithMembersLinkCommand extends ProjectLinkCommand {
     public ProjectWithMembersLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ScheduleLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/ScheduleLinkCommand.java
@@ -3,10 +3,7 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.ScheduleDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ScheduleLinkCommand extends LinkCommand<ScheduleDto> {
     public ScheduleLinkCommand(LinkReceiver linkReceiver, ScheduleDto dto, UriInfo uriInfo) {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserLinkCommand.java
@@ -3,7 +3,6 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
 import jakarta.ws.rs.core.UriInfo;
-
 import java.net.URI;
 
 public class UserLinkCommand extends LinkCommand<UserLightDto> {

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithEventsLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithEventsLinkCommand.java
@@ -1,0 +1,30 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.ports.interactor.datatransferobjects.EventDto;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.util.List;
+
+public class UserWithEventsLinkCommand extends UserLinkCommand {
+    public UserWithEventsLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        super(linkReceiver, userLightDto, uriInfo);
+    }
+    @Override
+    public URI execute() {
+        URI userUri = super.execute();
+        List<EventDto> eventDtos = dto.getEvents();
+        for(EventDto eventDto :eventDtos) {
+            URI eventUri = linkReceiver
+                    .getUriForEvent(
+                            uriInfo.getBaseUriBuilder(),
+                            eventDto.getEventId());
+            eventDto.addLink(
+                    eventUri.toString(),
+                    "event");
+        }
+        return userUri;
+    }
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithMembersLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithMembersLinkCommand.java
@@ -1,0 +1,37 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.util.List;
+
+public class UserWithMembersLinkCommand extends UserLinkCommand {
+    public UserWithMembersLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        super(linkReceiver, userLightDto, uriInfo);
+    }
+    @Override
+    public URI execute() {
+        URI userUri = super.execute();
+        List<MemberDto> memberDtos = dto.getMembers();
+        for(MemberDto memberDto :memberDtos) {
+            URI memberUri = linkReceiver
+                    .getUriForMember(
+                            uriInfo.getBaseUriBuilder(),
+                            memberDto.getMemberId());
+            memberDto.addLink(
+                    memberUri.toString(),
+                    "member");
+            URI projectUri = linkReceiver
+                    .getUriForProject(
+                            uriInfo.getBaseUriBuilder(),
+                            memberDto.getProjectId());
+            memberDto.addLink(
+                    projectUri.toString(),
+                    "project");
+        }
+        return userUri;
+    }
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithProjectsLinkCommand.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcommands/UserWithProjectsLinkCommand.java
@@ -1,0 +1,29 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcommands;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+
+public class UserWithProjectsLinkCommand extends UserLinkCommand {
+    public UserWithProjectsLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        super(linkReceiver, userLightDto, uriInfo);
+    }
+    @Override
+    public URI execute() {
+        URI userUri = super.execute();
+        List<ProjectDto> projectDtos = dto.getProjects();
+        for(ProjectDto projectDto :projectDtos) {
+            URI projectUri = linkReceiver
+                    .getUriForProject(
+                            uriInfo.getBaseUriBuilder(),
+                            projectDto.getProjectId());
+            projectDto.addLink(
+                    projectUri.toString(),
+                    "project");
+        }
+        return userUri;
+    }
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/EventLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/EventLinkCreator.java
@@ -1,21 +1,21 @@
 package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.EventWithPollsLinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.EventLinkCommand;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
 import com.knotslicer.server.ports.interactor.datatransferobjects.EventDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
-import com.knotslicer.server.adapters.rest.linkgenerator.WithChildren;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
 @ProcessAs(ProcessType.EVENT)
-@WithChildren
+@Default
 @ApplicationScoped
-public class EventWithPollsLinkCreatorImpl implements LinkCreator<EventDto> {
+public class EventLinkCreator implements LinkCreator<EventDto> {
     @Override
     public LinkCommand<EventDto> createLinkCommand(LinkReceiver linkReceiver, EventDto eventDto, UriInfo uriInfo) {
-        return new EventWithPollsLinkCommand(linkReceiver, eventDto, uriInfo);
+        return new EventLinkCommand(linkReceiver, eventDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/EventWithPollsLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/EventWithPollsLinkCreator.java
@@ -1,21 +1,21 @@
 package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.EventLinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.EventWithPollsLinkCommand;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
 import com.knotslicer.server.ports.interactor.datatransferobjects.EventDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.adapters.rest.linkgenerator.WithChildren;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
 @ProcessAs(ProcessType.EVENT)
-@Default
+@WithChildren
 @ApplicationScoped
-public class EventLinkCreatorImpl implements LinkCreator<EventDto> {
+public class EventWithPollsLinkCreator implements LinkCreator<EventDto> {
     @Override
     public LinkCommand<EventDto> createLinkCommand(LinkReceiver linkReceiver, EventDto eventDto, UriInfo uriInfo) {
-        return new EventLinkCommand(linkReceiver, eventDto, uriInfo);
+        return new EventWithPollsLinkCommand(linkReceiver, eventDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/MemberLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/MemberLinkCreator.java
@@ -2,20 +2,20 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.PollAnswerLinkCommand;
-import com.knotslicer.server.ports.interactor.datatransferobjects.PollAnswerDto;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.MemberLinkCommand;
+import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.POLLANSWER)
+@ProcessAs(ProcessType.MEMBER)
 @Default
 @ApplicationScoped
-public class PollAnswerLinkCreatorImpl implements LinkCreator<PollAnswerDto> {
+public class MemberLinkCreator implements LinkCreator<MemberDto> {
     @Override
-    public LinkCommand<PollAnswerDto> createLinkCommand(LinkReceiver linkReceiver, PollAnswerDto pollAnswerDto, UriInfo uriInfo) {
-        return new PollAnswerLinkCommand(linkReceiver, pollAnswerDto, uriInfo);
+    public LinkCommand<MemberDto> createLinkCommand(LinkReceiver linkReceiver, MemberDto memberDto, UriInfo uriInfo) {
+        return new MemberLinkCommand(linkReceiver, memberDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/MemberWithSchedulesLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/MemberWithSchedulesLinkCreator.java
@@ -3,19 +3,19 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.WithChildren;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.ProjectWithMembersLinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.MemberWithSchedulesLinkCommand;
+import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
-import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.PROJECT)
+@ProcessAs(ProcessType.MEMBER)
 @WithChildren
 @ApplicationScoped
-public class ProjectWithMembersLinkCreatorImpl implements LinkCreator<ProjectDto> {
+public class MemberWithSchedulesLinkCreator implements LinkCreator<MemberDto> {
     @Override
-    public LinkCommand<ProjectDto> createLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {
-        return new ProjectWithMembersLinkCommand(linkReceiver, projectDto, uriInfo);
+    public LinkCommand<MemberDto> createLinkCommand(LinkReceiver linkReceiver, MemberDto memberDto, UriInfo uriInfo) {
+        return new MemberWithSchedulesLinkCommand(linkReceiver, memberDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/PollAnswerLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/PollAnswerLinkCreator.java
@@ -2,20 +2,20 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.PollLinkCommand;
-import com.knotslicer.server.ports.interactor.datatransferobjects.PollDto;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.PollAnswerLinkCommand;
+import com.knotslicer.server.ports.interactor.datatransferobjects.PollAnswerDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.POLL)
+@ProcessAs(ProcessType.POLLANSWER)
 @Default
 @ApplicationScoped
-public class PollLinkCreatorImpl implements LinkCreator<PollDto> {
+public class PollAnswerLinkCreator implements LinkCreator<PollAnswerDto> {
     @Override
-    public LinkCommand<PollDto> createLinkCommand(LinkReceiver linkReceiver, PollDto pollDto, UriInfo uriInfo) {
-        return new PollLinkCommand(linkReceiver, pollDto, uriInfo);
+    public LinkCommand<PollAnswerDto> createLinkCommand(LinkReceiver linkReceiver, PollAnswerDto pollAnswerDto, UriInfo uriInfo) {
+        return new PollAnswerLinkCommand(linkReceiver, pollAnswerDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/PollLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/PollLinkCreator.java
@@ -2,20 +2,20 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.ProjectLinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.PollLinkCommand;
+import com.knotslicer.server.ports.interactor.datatransferobjects.PollDto;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
-import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.PROJECT)
+@ProcessAs(ProcessType.POLL)
 @Default
 @ApplicationScoped
-public class ProjectLinkCreatorImpl implements LinkCreator<ProjectDto> {
+public class PollLinkCreator implements LinkCreator<PollDto> {
     @Override
-    public LinkCommand<ProjectDto> createLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {
-        return new ProjectLinkCommand(linkReceiver, projectDto, uriInfo);
+    public LinkCommand<PollDto> createLinkCommand(LinkReceiver linkReceiver, PollDto pollDto, UriInfo uriInfo) {
+        return new PollLinkCommand(linkReceiver, pollDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ProjectLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ProjectLinkCreator.java
@@ -2,20 +2,20 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.MemberLinkCommand;
-import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.ProjectLinkCommand;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.MEMBER)
+@ProcessAs(ProcessType.PROJECT)
 @Default
 @ApplicationScoped
-public class MemberLinkCreatorImpl implements LinkCreator<MemberDto> {
+public class ProjectLinkCreator implements LinkCreator<ProjectDto> {
     @Override
-    public LinkCommand<MemberDto> createLinkCommand(LinkReceiver linkReceiver, MemberDto memberDto, UriInfo uriInfo) {
-        return new MemberLinkCommand(linkReceiver, memberDto, uriInfo);
+    public LinkCommand<ProjectDto> createLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {
+        return new ProjectLinkCommand(linkReceiver, projectDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ProjectWithMembersLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ProjectWithMembersLinkCreator.java
@@ -3,19 +3,19 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.WithChildren;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.MemberWithSchedulesLinkCommand;
-import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.ProjectWithMembersLinkCommand;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.ProjectDto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.MEMBER)
+@ProcessAs(ProcessType.PROJECT)
 @WithChildren
 @ApplicationScoped
-public class MemberWithSchedulesLinkCreatorImpl implements LinkCreator<MemberDto> {
+public class ProjectWithMembersLinkCreator implements LinkCreator<ProjectDto> {
     @Override
-    public LinkCommand<MemberDto> createLinkCommand(LinkReceiver linkReceiver, MemberDto memberDto, UriInfo uriInfo) {
-        return new MemberWithSchedulesLinkCommand(linkReceiver, memberDto, uriInfo);
+    public LinkCommand<ProjectDto> createLinkCommand(LinkReceiver linkReceiver, ProjectDto projectDto, UriInfo uriInfo) {
+        return new ProjectWithMembersLinkCommand(linkReceiver, projectDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ScheduleLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/ScheduleLinkCreator.java
@@ -11,7 +11,7 @@ import jakarta.ws.rs.core.UriInfo;
 
 @ProcessAs(ProcessType.SCHEDULE)
 @ApplicationScoped
-public class ScheduleLinkCreatorImpl implements LinkCreator<ScheduleDto> {
+public class ScheduleLinkCreator implements LinkCreator<ScheduleDto> {
     @Override
     public LinkCommand<ScheduleDto> createLinkCommand(LinkReceiver linkReceiver, ScheduleDto scheduleDto, UriInfo uriInfo) {
         return new ScheduleLinkCommand(linkReceiver, scheduleDto, uriInfo);

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserLinkCreator.java
@@ -11,7 +11,7 @@ import jakarta.ws.rs.core.UriInfo;
 
 @ProcessAs(ProcessType.USER)
 @ApplicationScoped
-public class UserLinkCreatorImpl implements LinkCreator<UserLightDto> {
+public class UserLinkCreator implements LinkCreator<UserLightDto> {
     @Override
     public LinkCommand<UserLightDto> createLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
         return new UserLinkCommand(linkReceiver, userLightDto, uriInfo);

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithEventsLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithEventsLinkCreator.java
@@ -2,18 +2,18 @@ package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.UserWithProjectsLinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.UserWithEventsLinkCommand;
 import com.knotslicer.server.ports.interactor.ProcessAs;
 import com.knotslicer.server.ports.interactor.ProcessType;
 import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.UriInfo;
 
-@ProcessAs(ProcessType.PROJECT)
+@ProcessAs(ProcessType.EVENT)
 @ApplicationScoped
-public class UserWithProjectsLinkCreatorImpl implements LinkCreator<UserLightDto> {
+public class UserWithEventsLinkCreator implements LinkCreator <UserLightDto> {
     @Override
     public LinkCommand<UserLightDto> createLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
-        return new UserWithProjectsLinkCommand(linkReceiver, userLightDto, uriInfo);
+        return new UserWithEventsLinkCommand(linkReceiver, userLightDto, uriInfo);
     }
 }

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithMembersLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithMembersLinkCreator.java
@@ -1,0 +1,19 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.UserWithMembersLinkCommand;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriInfo;
+
+@ProcessAs(ProcessType.MEMBER)
+@ApplicationScoped
+public class UserWithMembersLinkCreator implements LinkCreator <UserLightDto> {
+    @Override
+    public LinkCommand<UserLightDto> createLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        return new UserWithMembersLinkCommand(linkReceiver, userLightDto, uriInfo);
+    }
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithProjectsLinkCreator.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithProjectsLinkCreator.java
@@ -1,0 +1,19 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.UserWithProjectsLinkCommand;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriInfo;
+
+@ProcessAs(ProcessType.PROJECT)
+@ApplicationScoped
+public class UserWithProjectsLinkCreator implements LinkCreator<UserLightDto> {
+    @Override
+    public LinkCommand<UserLightDto> createLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        return new UserWithProjectsLinkCommand(linkReceiver, userLightDto, uriInfo);
+    }
+}

--- a/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithProjectsLinkCreatorImpl.java
+++ b/src/main/java/com/knotslicer/server/adapters/rest/linkgenerator/linkcreators/UserWithProjectsLinkCreatorImpl.java
@@ -1,0 +1,19 @@
+package com.knotslicer.server.adapters.rest.linkgenerator.linkcreators;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.LinkCommand;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcommands.UserWithProjectsLinkCommand;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriInfo;
+
+@ProcessAs(ProcessType.PROJECT)
+@ApplicationScoped
+public class UserWithProjectsLinkCreatorImpl implements LinkCreator<UserLightDto> {
+    @Override
+    public LinkCommand<UserLightDto> createLinkCommand(LinkReceiver linkReceiver, UserLightDto userLightDto, UriInfo uriInfo) {
+        return new UserWithProjectsLinkCommand(linkReceiver, userLightDto, uriInfo);
+    }
+}

--- a/src/main/java/com/knotslicer/server/ports/entitygateway/ChildDao.java
+++ b/src/main/java/com/knotslicer/server/ports/entitygateway/ChildDao.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 public interface ChildDao<T,P> {
     Optional<T> get(Long id);
     T update(T t, Long parentId);
-    void delete(Long id, Long parentId);
-    Long getPrimaryParentId(Long id);
+    void delete(Long id);
+    P getPrimaryParent(Long id);
     Optional<P> getPrimaryParentWithChildren(Long parentId);
 }

--- a/src/main/java/com/knotslicer/server/ports/entitygateway/ChildWithOneRequiredParentDao.java
+++ b/src/main/java/com/knotslicer/server/ports/entitygateway/ChildWithOneRequiredParentDao.java
@@ -1,5 +1,7 @@
 package com.knotslicer.server.ports.entitygateway;
 
+import com.knotslicer.server.domain.User;
+
 public interface ChildWithOneRequiredParentDao<T,P> extends ChildDao<T,P> {
     T create(T t, Long parentId);
 }

--- a/src/main/java/com/knotslicer/server/ports/entitygateway/ChildWithTwoParentsDao.java
+++ b/src/main/java/com/knotslicer/server/ports/entitygateway/ChildWithTwoParentsDao.java
@@ -4,6 +4,6 @@ import java.util.Optional;
 
 public interface ChildWithTwoParentsDao<T,P,S> extends ChildDao<T, P> {
     T create(T t, Long primaryParentId, Long secondaryParentId);
-    Long getSecondaryParentId(Long id);
+    S getSecondaryParent(Long id);
     Optional<S> getSecondaryParentWithChildren(Long secondaryParentId);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/EventDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/EventDto.java
@@ -18,6 +18,4 @@ public interface EventDto extends Linkable {
     void setEventDescription(String eventDescription);
     List<PollDto> getPolls();
     void setPolls(List<PollDto> pollDtos);
-    List<Link> getLinks();
-    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/EventDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/EventDtoImpl.java
@@ -62,6 +62,4 @@ public class EventDtoImpl implements EventDto, Serializable {
     public void setPolls(List<PollDto> polls) {this.polls = polls;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/Linkable.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/Linkable.java
@@ -1,5 +1,9 @@
 package com.knotslicer.server.ports.interactor.datatransferobjects;
 
+import java.util.List;
+
 public interface Linkable {
     void addLink(String url, String rel);
+    List<Link> getLinks();
+    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/Linkable.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/Linkable.java
@@ -5,5 +5,4 @@ import java.util.List;
 public interface Linkable {
     void addLink(String url, String rel);
     List<Link> getLinks();
-    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/MemberDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/MemberDto.java
@@ -20,6 +20,4 @@ public interface MemberDto extends Linkable {
     void setRoleDescription(String roleDescription);
     List<ScheduleDto> getSchedules();
     void setSchedules(List<ScheduleDto> schedules);
-    List<Link> getLinks();
-    public void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/MemberDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/MemberDtoImpl.java
@@ -55,6 +55,4 @@ public class MemberDtoImpl implements MemberDto, Serializable {
     public void setSchedules(List<ScheduleDto> schedules) {this.schedules = schedules;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollAnswerDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollAnswerDto.java
@@ -14,6 +14,4 @@ public interface PollAnswerDto extends Linkable {
     void setPollAnswerId(Long pollAnswerId);
     Boolean isApproved();
     void setApproved(Boolean approved);
-    List<Link> getLinks();
-    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollAnswerDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollAnswerDtoImpl.java
@@ -44,6 +44,4 @@ public class PollAnswerDtoImpl implements PollAnswerDto, Serializable {
     }
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollDto.java
@@ -16,6 +16,4 @@ public interface PollDto extends Linkable {
     void setEndTimeUtc(LocalDateTime endTimeUtc);
     List<PollAnswerDto> getPollAnswers();
     void setPollAnswers(List<PollAnswerDto> pollAnswerDtos);
-    List<Link> getLinks();
-    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/PollDtoImpl.java
@@ -53,6 +53,4 @@ public class PollDtoImpl implements PollDto, Serializable {
     public void setPollAnswers(List<PollAnswerDto> pollAnswers) {this.pollAnswers = pollAnswers;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ProjectDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ProjectDto.java
@@ -16,6 +16,4 @@ public interface ProjectDto extends Linkable {
     void setProjectDescription(String projectDescription);
     List<MemberDto> getMembers();
     void setMembers(List<MemberDto> members);
-    List<Link> getLinks();
-    void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ProjectDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ProjectDtoImpl.java
@@ -54,6 +54,4 @@ public class ProjectDtoImpl implements ProjectDto, Serializable {
     public void setMembers(List<MemberDto> members) {this.members = members;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ScheduleDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ScheduleDto.java
@@ -15,6 +15,4 @@ public interface ScheduleDto extends Linkable {
     void setStartTimeUtc(LocalDateTime startTimeUtc);
     LocalDateTime getEndTimeUtc();
     void setEndTimeUtc(LocalDateTime endTimeUtc);
-    List<Link> getLinks();
-    public void setLinks(List<Link> links);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ScheduleDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/ScheduleDtoImpl.java
@@ -49,6 +49,4 @@ public class ScheduleDtoImpl implements ScheduleDto, Serializable {
     }
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
@@ -12,9 +12,9 @@ public class UserDtoImpl implements UserDto, Serializable {
     private String userName;
     private String userDescription;
     private ZoneId timeZone;
-    private List<ProjectDto> projects;
-    private List<MemberDto> members;
-    private List<EventDto> events;
+    private List<ProjectDto> projects = new LinkedList<>();
+    private List<MemberDto> members = new LinkedList<>();
+    private List<EventDto> events = new LinkedList<>();
     private List<Link> links = new LinkedList<>();
 
     @Override

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
@@ -74,6 +74,4 @@ public class UserDtoImpl implements UserDto, Serializable {
     public void setTimeZone(ZoneId timeZone) {this.timeZone = timeZone;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserDtoImpl.java
@@ -12,6 +12,9 @@ public class UserDtoImpl implements UserDto, Serializable {
     private String userName;
     private String userDescription;
     private ZoneId timeZone;
+    private List<ProjectDto> projects;
+    private List<MemberDto> members;
+    private List<EventDto> events;
     private List<Link> links = new LinkedList<>();
 
     @Override
@@ -56,7 +59,21 @@ public class UserDtoImpl implements UserDto, Serializable {
     @Override
     public ZoneId getTimeZone() {return timeZone;}
     @Override
+    public List<ProjectDto> getProjects() {return projects;}
+    @Override
+    public void setProjects(List<ProjectDto> projects) {this.projects = projects;}
+    @Override
+    public List<MemberDto> getMembers() {return members;}
+    @Override
+    public void setMembers(List<MemberDto> members) {this.members = members;}
+    @Override
+    public List<EventDto> getEvents() {return events;}
+    @Override
+    public void setEvents(List<EventDto> events) {this.events = events;}
+    @Override
     public void setTimeZone(ZoneId timeZone) {this.timeZone = timeZone;}
+    @Override
     public List<Link> getLinks() {return links;}
+    @Override
     public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDto.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDto.java
@@ -2,6 +2,7 @@ package com.knotslicer.server.ports.interactor.datatransferobjects;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.ZoneId;
+import java.util.List;
 
 @JsonDeserialize(as = UserLightDtoImpl.class)
 public interface UserLightDto extends Linkable {
@@ -13,4 +14,10 @@ public interface UserLightDto extends Linkable {
     void setUserDescription(String userDescription);
     ZoneId getTimeZone();
     void setTimeZone(ZoneId timeZone);
+    List<ProjectDto> getProjects();
+    public void setProjects(List<ProjectDto> projects);
+    public List<MemberDto> getMembers();
+    public void setMembers(List<MemberDto> members);
+    public List<EventDto> getEvents();
+    public void setEvents(List<EventDto> events);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
@@ -11,9 +11,9 @@ public class UserLightDtoImpl implements UserLightDto, Serializable {
     private String userName;
     private String userDescription;
     private ZoneId timeZone;
-    private List<ProjectDto> projects;
-    private List<MemberDto> members;
-    private List<EventDto> events;
+    private List<ProjectDto> projects = new LinkedList<>();
+    private List<MemberDto> members = new LinkedList<>();
+    private List<EventDto> events = new LinkedList<>();
     private List<Link> links = new LinkedList<>();
 
     @Override

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
@@ -11,7 +11,11 @@ public class UserLightDtoImpl implements UserLightDto, Serializable {
     private String userName;
     private String userDescription;
     private ZoneId timeZone;
+    private List<ProjectDto> projects;
+    private List<MemberDto> members;
+    private List<EventDto> events;
     private List<Link> links = new LinkedList<>();
+
     @Override
     public void addLink(String url, String rel) {
         Link link = createLink();
@@ -39,6 +43,20 @@ public class UserLightDtoImpl implements UserLightDto, Serializable {
     public ZoneId getTimeZone() {return timeZone;}
     @Override
     public void setTimeZone(ZoneId timeZone) {this.timeZone = timeZone;}
+    @Override
+    public List<ProjectDto> getProjects() {return projects;}
+    @Override
+    public void setProjects(List<ProjectDto> projects) {this.projects = projects;}
+    @Override
+    public List<MemberDto> getMembers() {return members;}
+    @Override
+    public void setMembers(List<MemberDto> members) {this.members = members;}
+    @Override
+    public List<EventDto> getEvents() {return events;}
+    @Override
+    public void setEvents(List<EventDto> events) {this.events = events;}
+    @Override
     public List<Link> getLinks() {return links;}
+    @Override
     public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/datatransferobjects/UserLightDtoImpl.java
@@ -57,6 +57,4 @@ public class UserLightDtoImpl implements UserLightDto, Serializable {
     public void setEvents(List<EventDto> events) {this.events = events;}
     @Override
     public List<Link> getLinks() {return links;}
-    @Override
-    public void setLinks(List<Link> links) {this.links = links;}
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/mappers/EntityDtoMapper.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/mappers/EntityDtoMapper.java
@@ -6,6 +6,9 @@ import com.knotslicer.server.domain.*;
 public interface EntityDtoMapper {
     UserDto toDto(User userInput);
     UserLightDto toLightDto(User userInput);
+    UserLightDto addProjectDtosToUserLightDto(UserLightDto userLightDto, User userInput);
+    UserLightDto addMemberDtosToUserLightDto(UserLightDto userLightDto, User userInput);
+    UserLightDto addEventDtosToUserLightDto(UserLightDto userLightDto, User userInput);
     User toEntity(UserDto userDtoInput);
     User toEntity(UserLightDto userLightDtoInput, User userToBeModified);
     ProjectDto toDto(Project projectInput, Long userId);
@@ -18,18 +21,18 @@ public interface EntityDtoMapper {
     Member toEntity(MemberDto memberDtoInput, Member memberToBeModified);
 
     EventDto toDto(Event eventInput, Long userId);
+    EventDto addPollDtosToEventDto(EventDto eventDto, Event eventInput);
     Event toEntity(EventDto eventDtoInput);
     Event toEntity(EventDto eventDtoInput, Event eventToBeModified);
-    EventDto addPollDtosToEventDto(EventDto eventDto, Event eventInput);
 
     ScheduleDto toDto(Schedule scheduleInput, Long memberId);
     Schedule toEntity(ScheduleDto scheduleDtoInput);
     Schedule toEntity(ScheduleDto scheduleDtoInput, Schedule scheduleToBeModified);
 
     PollDto toDto(Poll pollInput, Long eventId);
+    PollDto addPollAnswerDtosToPollDto(PollDto pollDto, Poll pollInput);
     Poll toEntity(PollDto pollDtoInput);
     Poll toEntity(PollDto pollDtoInput, Poll pollToBeModified);
-    PollDto addPollAnswerDtosToPollDto(PollDto pollDto, Poll pollInput);
 
     PollAnswerDto toDto(PollAnswer pollAnswerInput, Long pollId, Long memberId);
     PollAnswer toEntity(PollAnswerDto pollAnswerDtoInput);

--- a/src/main/java/com/knotslicer/server/ports/interactor/mappers/EntityDtoMapperImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/mappers/EntityDtoMapperImpl.java
@@ -42,6 +42,46 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
         return userLightDto;
     }
     @Override
+    public UserLightDto addProjectDtosToUserLightDto(UserLightDto userLightDto, User userInput) {
+        UserImpl userImpl = (UserImpl) userInput;
+        List<ProjectImpl> projectImpls = userImpl.getProjects();
+        List<ProjectDto> projectDtos = new LinkedList<>();
+        Long userId = userInput.getUserId();
+        for(ProjectImpl projectImpl: projectImpls) {
+            ProjectDto projectDto = toDto(
+                    projectImpl,
+                    userId);
+            projectDtos.add(projectDto);
+        }
+        userLightDto.setProjects(projectDtos);
+        return userLightDto;
+    }
+    @Override
+    public UserLightDto addMemberDtosToUserLightDto(UserLightDto userLightDto, User userInput) {
+        /*UserImpl userImpl = (UserImpl) userInput;
+        List<MemberImpl> memberImpls = userImpl.getMembers();
+        List<MemberDto> memberDtos = new LinkedList<>();
+        for(MemberImpl memberImpl: memberImpls) {
+            MemberDto memberDto = toDto(memberImpl, );
+        }*/
+        return null;
+    }
+    @Override
+    public UserLightDto addEventDtosToUserLightDto(UserLightDto userLightDto, User userInput) {
+        UserImpl userImpl = (UserImpl) userInput;
+        List<EventImpl> eventImpls = userImpl.getEvents();
+        List<EventDto> eventDtos = new LinkedList<>();
+        Long userId = userInput.getUserId();
+        for(EventImpl eventImpl: eventImpls) {
+            EventDto eventDto = toDto(
+                    eventImpl,
+                    userId);
+            eventDtos.add(eventDto);
+        }
+        userLightDto.setEvents(eventDtos);
+        return userLightDto;
+    }
+    @Override
     public User toEntity(UserDto userDtoInput) {
         User userToBeModified = entityCreator.createUser();
         userToBeModified.setEmail(
@@ -127,6 +167,7 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
                 memberInput.getRoleDescription());
         return memberDto;
     }
+    @Override
     public MemberDto addScheduleDtosToMemberDto(MemberDto memberDto, Member memberInput) {
         MemberImpl memberImpl = (MemberImpl) memberInput;
         List<ScheduleImpl> scheduleImpls = memberImpl.getSchedules();
@@ -174,6 +215,20 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
         return eventDto;
     }
     @Override
+    public EventDto addPollDtosToEventDto(EventDto eventDto, Event eventInput) {
+        EventImpl eventImpl = (EventImpl) eventInput;
+        List<PollImpl> pollImpls = eventImpl.getPolls();
+        List<PollDto> pollDtos = new LinkedList<>();
+        Long eventId = eventImpl.getEventId();
+        for(PollImpl pollImpl: pollImpls) {
+            PollDto pollDto =
+                    toDto(pollImpl, eventId);
+            pollDtos.add(pollDto);
+        }
+        eventDto.setPolls(pollDtos);
+        return eventDto;
+    }
+    @Override
     public Event toEntity(EventDto eventDtoInput) {
         Event event = entityCreator.createEvent();
         setEntityVariables(event, eventDtoInput);
@@ -191,20 +246,6 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
     public Event toEntity(EventDto eventDtoInput, Event eventToBeModified) {
         setEntityVariables(eventToBeModified, eventDtoInput);
         return eventToBeModified;
-    }
-    @Override
-    public EventDto addPollDtosToEventDto(EventDto eventDto, Event eventInput) {
-        EventImpl eventImpl = (EventImpl) eventInput;
-        List<PollImpl> pollImpls = eventImpl.getPolls();
-        List<PollDto> pollDtos = new LinkedList<>();
-        Long eventId = eventImpl.getEventId();
-        for(PollImpl pollImpl: pollImpls) {
-            PollDto pollDto =
-                    toDto(pollImpl, eventId);
-            pollDtos.add(pollDto);
-        }
-        eventDto.setPolls(pollDtos);
-        return eventDto;
     }
     @Override
     public ScheduleDto toDto(Schedule scheduleInput, Long memberId) {
@@ -248,22 +289,6 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
         return pollDto;
     }
     @Override
-    public Poll toEntity(PollDto pollDtoInput) {
-        Poll poll = entityCreator.createPoll();
-        setEntityVariables(poll, pollDtoInput);
-        return poll;
-    }
-    private void setEntityVariables(Poll pollToBeModified, PollDto pollDtoInput) {
-        pollToBeModified.setStartTimeUtc(
-                pollDtoInput.getStartTimeUtc());
-        pollToBeModified.setEndTimeUtc(
-                pollDtoInput.getEndTimeUtc());
-    }
-    @Override
-    public Poll toEntity(PollDto pollDtoInput, Poll pollToBeModified) {
-        setEntityVariables(pollToBeModified, pollDtoInput);
-        return pollToBeModified;
-    }
     public PollDto addPollAnswerDtosToPollDto(PollDto pollDto, Poll pollInput) {
         PollImpl pollImpl = (PollImpl) pollInput;
         List<PollAnswerImpl> pollAnswerImpls =
@@ -282,6 +307,23 @@ public class EntityDtoMapperImpl implements EntityDtoMapper {
         }
         pollDto.setPollAnswers(pollAnswerDtos);
         return pollDto;
+    }
+    @Override
+    public Poll toEntity(PollDto pollDtoInput) {
+        Poll poll = entityCreator.createPoll();
+        setEntityVariables(poll, pollDtoInput);
+        return poll;
+    }
+    private void setEntityVariables(Poll pollToBeModified, PollDto pollDtoInput) {
+        pollToBeModified.setStartTimeUtc(
+                pollDtoInput.getStartTimeUtc());
+        pollToBeModified.setEndTimeUtc(
+                pollDtoInput.getEndTimeUtc());
+    }
+    @Override
+    public Poll toEntity(PollDto pollDtoInput, Poll pollToBeModified) {
+        setEntityVariables(pollToBeModified, pollDtoInput);
+        return pollToBeModified;
     }
     @Override
     public PollAnswerDto toDto(PollAnswer pollAnswerInput, Long pollId, Long memberId) {

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/EventServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/EventServiceImpl.java
@@ -33,7 +33,8 @@ public class EventServiceImpl implements ParentService<EventDto> {
     public EventDto get(Long eventId) {
         Optional<Event> optionalEvent = eventDao.get(eventId);
         Event event = unpackOptionalEvent(optionalEvent);
-        Long userId = eventDao.getPrimaryParentId(eventId);
+        User user = eventDao.getPrimaryParent(eventId);
+        Long userId = user.getUserId();
         return entityDtoMapper
                 .toDto(event, userId);
     }
@@ -45,8 +46,9 @@ public class EventServiceImpl implements ParentService<EventDto> {
         Optional<Event> optionalEvent =
                 pollDao.getPrimaryParentWithChildren(eventId);
         Event event = unpackOptionalEvent(optionalEvent);
-        Long userId = eventDao
-                .getPrimaryParentId(eventId);
+        User user = eventDao
+                .getPrimaryParent(eventId);
+        Long userId = user.getUserId();
         EventDto eventDto = entityDtoMapper
                 .toDto(event, userId);
         return entityDtoMapper
@@ -60,8 +62,9 @@ public class EventServiceImpl implements ParentService<EventDto> {
         Event eventToBeModified = unpackOptionalEvent(optionalEvent);
         eventToBeModified = entityDtoMapper
                 .toEntity(eventDto, eventToBeModified);
-        Long userId = eventDao
-                .getPrimaryParentId(eventId);
+        User user = eventDao
+                .getPrimaryParent(eventId);
+        Long userId = user.getUserId();
         Event updatedEvent = eventDao
                 .update(eventToBeModified,
                         userId);
@@ -70,8 +73,7 @@ public class EventServiceImpl implements ParentService<EventDto> {
     }
     @Override
     public void delete(Long eventId) {
-        Long userId = eventDao.getPrimaryParentId(eventId);
-        eventDao.delete(eventId, userId);
+        eventDao.delete(eventId);
     }
     @Inject
     public EventServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/MemberServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/MemberServiceImpl.java
@@ -43,8 +43,10 @@ public class MemberServiceImpl implements ParentService<MemberDto> {
         Optional<Member> optionalMember = memberDao
                 .get(memberId);
         Member member = unpackOptionalMember(optionalMember);
-        Long userId = memberDao.getPrimaryParentId(memberId);
-        Long projectId = memberDao.getSecondaryParentId(memberId);
+        User user = memberDao.getPrimaryParent(memberId);
+        Long userId = user.getUserId();
+        Project project = memberDao.getSecondaryParent(memberId);
+        Long projectId = project.getProjectId();;
         return entityDtoMapper.toDto(
                 member,
                 userId,
@@ -57,8 +59,10 @@ public class MemberServiceImpl implements ParentService<MemberDto> {
     public MemberDto getWithChildren(Long memberId) {
         Optional<Member> optionalMember = scheduleDao.getPrimaryParentWithChildren(memberId);
         Member member = unpackOptionalMember(optionalMember);
-        Long userId = memberDao.getPrimaryParentId(memberId);
-        Long projectId = memberDao.getSecondaryParentId(memberId);
+        User user = memberDao.getPrimaryParent(memberId);
+        Long userId = user.getUserId();
+        Project project = memberDao.getSecondaryParent(memberId);
+        Long projectId = project.getProjectId();
         MemberDto memberDto =
                 entityDtoMapper.toDto(
                         member,
@@ -80,11 +84,15 @@ public class MemberServiceImpl implements ParentService<MemberDto> {
                 .toEntity(memberDto,
                         memberToBeModified);
 
-        Long userId = memberDao.getPrimaryParentId(memberId);
+        User user = memberDao.getPrimaryParent(memberId);
+        Long userId = user.getUserId();
         Member updatedMember =
-                memberDao.update(memberToBeModified, userId);
+                memberDao.update(
+                        memberToBeModified,
+                        userId);
 
-        Long projectId = memberDao.getSecondaryParentId(memberId);
+        Project project = memberDao.getSecondaryParent(memberId);
+        Long projectId = project.getProjectId();
         return entityDtoMapper.toDto(
                 updatedMember,
                 userId,
@@ -92,10 +100,7 @@ public class MemberServiceImpl implements ParentService<MemberDto> {
     }
     @Override
     public void delete(Long memberId) {
-        Long userId = memberDao.getPrimaryParentId(memberId);
-        memberDao.delete(
-                memberId,
-                userId);
+        memberDao.delete(memberId);
     }
     @Inject
     public MemberServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/PollAnswerServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/PollAnswerServiceImpl.java
@@ -39,10 +39,12 @@ public class PollAnswerServiceImpl implements Service<PollAnswerDto> {
                 pollAnswerDao.get(pollAnswerId);
         PollAnswer pollAnswer =
                 unpackOptionalPollAnswer(optionalPollAnswer);
-        Long pollId = pollAnswerDao
-                .getPrimaryParentId(pollAnswerId);
-        Long memberId = pollAnswerDao
-                .getSecondaryParentId(pollAnswerId);
+        Poll poll = pollAnswerDao
+                .getPrimaryParent(pollAnswerId);
+        Long pollId = poll.getPollId();
+        Member member = pollAnswerDao
+                .getSecondaryParent(pollAnswerId);
+        Long memberId = member.getMemberId();
         return entityDtoMapper
                 .toDto(pollAnswer,
                         pollId,
@@ -63,8 +65,9 @@ public class PollAnswerServiceImpl implements Service<PollAnswerDto> {
         Long pollId = pollAnswerDto.getPollId();
         PollAnswer updatedPollAnswer = pollAnswerDao
                 .update(pollAnswerToBeModified, pollId);
-        Long memberId = pollAnswerDao
-                .getSecondaryParentId(pollAnswerId);
+        Member member = pollAnswerDao
+                .getSecondaryParent(pollAnswerId);
+        Long memberId = member.getMemberId();
         return entityDtoMapper.toDto(
                 updatedPollAnswer,
                 pollId,
@@ -73,11 +76,7 @@ public class PollAnswerServiceImpl implements Service<PollAnswerDto> {
 
     @Override
     public void delete(Long pollAnswerId) {
-        Long pollId = pollAnswerDao
-                .getPrimaryParentId(pollAnswerId);
-        pollAnswerDao.delete(
-                pollAnswerId,
-                pollId);
+        pollAnswerDao.delete(pollAnswerId);
     }
     @Inject
     public PollAnswerServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/PollServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/PollServiceImpl.java
@@ -35,7 +35,8 @@ public class PollServiceImpl implements ParentService<PollDto> {
     public PollDto get(Long pollId) {
         Optional<Poll> optionalPoll = pollDao.get(pollId);
         Poll poll = unpackOptionalPoll(optionalPoll);
-        Long eventId = pollDao.getPrimaryParentId(pollId);
+        Event event = pollDao.getPrimaryParent(pollId);
+        Long eventId = event.getEventId();
         return entityDtoMapper
                 .toDto(poll, eventId);
     }
@@ -47,10 +48,12 @@ public class PollServiceImpl implements ParentService<PollDto> {
         Optional<Poll> optionalPoll =
                 pollAnswerDao.getPrimaryParentWithChildren(pollId);
         Poll poll = unpackOptionalPoll(optionalPoll);
-        Long eventId = pollDao
-                .getPrimaryParentId(pollId);
+        Event event = pollDao
+                .getPrimaryParent(pollId);
+        Long eventId = event.getEventId();
         PollDto pollDto = entityDtoMapper
-                .toDto(poll, eventId);
+                .toDto(poll,
+                        eventId);
         return entityDtoMapper
                 .addPollAnswerDtosToPollDto(pollDto, poll);
     }
@@ -61,8 +64,9 @@ public class PollServiceImpl implements ParentService<PollDto> {
         Poll pollLToBeModified = unpackOptionalPoll(optionalPoll);
         pollLToBeModified = entityDtoMapper
                 .toEntity(pollDto, pollLToBeModified);
-        Long eventId = pollDao
-                .getPrimaryParentId(pollId);
+        Event event = pollDao
+                .getPrimaryParent(pollId);
+        Long eventId = event.getEventId();
         Poll updatedPoll = pollDao
                 .update(pollLToBeModified, eventId);
         return entityDtoMapper
@@ -70,8 +74,7 @@ public class PollServiceImpl implements ParentService<PollDto> {
     }
     @Override
     public void delete(Long pollId) {
-        Long eventId = pollDao.getPrimaryParentId(pollId);
-        pollDao.delete(pollId, eventId);
+        pollDao.delete(pollId);
     }
     @Inject
     public PollServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/ProjectServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/ProjectServiceImpl.java
@@ -34,16 +34,17 @@ public class ProjectServiceImpl implements ParentService<ProjectDto> {
     public ProjectDto get(Long projectId) {
         Optional<Project> optionalProject = projectDao.get(projectId);
         Project project = unpackOptionalProject(optionalProject);
-        Long userId = projectDao.getPrimaryParentId(projectId);
+        User user = projectDao.getPrimaryParent(projectId);
+        Long userId = user.getUserId();
         return entityDtoMapper
-                .toDto(project,
-                        userId);
+                .toDto(project, userId);
     }
     @Override
     public ProjectDto getWithChildren(Long projectId) {
         Optional<Project> optionalProject = memberDao.getSecondaryParentWithChildren(projectId);
         Project project = unpackOptionalProject(optionalProject);
-        Long userId = projectDao.getPrimaryParentId(projectId);
+        User user = projectDao.getPrimaryParent(projectId);
+        Long userId = user.getUserId();
         ProjectDto projectDto =
                 entityDtoMapper.toDto(
                         project,
@@ -64,8 +65,9 @@ public class ProjectServiceImpl implements ParentService<ProjectDto> {
         Project projectToBeModified = unpackOptionalProject(optionalProject);
         projectToBeModified = entityDtoMapper
                 .toEntity(projectDto, projectToBeModified);
-        Long userId = projectDao
-                .getPrimaryParentId(projectId);
+        User user = projectDao
+                .getPrimaryParent(projectId);
+        Long userId = user.getUserId();
         Project updatedProject = projectDao
                 .update(projectToBeModified, userId);
         return entityDtoMapper.toDto(
@@ -74,8 +76,7 @@ public class ProjectServiceImpl implements ParentService<ProjectDto> {
     }
     @Override
     public void delete(Long projectId) {
-        Long userId = projectDao.getPrimaryParentId(projectId);
-        projectDao.delete(projectId, userId);
+        projectDao.delete(projectId);
     }
     @Inject
     public ProjectServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/ScheduleServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/ScheduleServiceImpl.java
@@ -34,7 +34,8 @@ public class ScheduleServiceImpl implements Service<ScheduleDto> {
     public ScheduleDto get(Long scheduleId) {
         Optional<Schedule> optionalSchedule = scheduleDao.get(scheduleId);
         Schedule schedule = unpackOptionalSchedule(optionalSchedule);
-        Long memberId = scheduleDao.getPrimaryParentId(scheduleId);
+        Member member = scheduleDao.getPrimaryParent(scheduleId);
+        Long memberId = member.getMemberId();
         return entityDtoMapper.toDto(
                 schedule,
                 memberId);
@@ -63,10 +64,7 @@ public class ScheduleServiceImpl implements Service<ScheduleDto> {
     }
     @Override
     public void delete(Long scheduleId) {
-        Long memberId = scheduleDao.getPrimaryParentId(scheduleId);
-        scheduleDao.delete(
-                scheduleId,
-                memberId);
+        scheduleDao.delete(scheduleId);
     }
     @Inject
     public ScheduleServiceImpl(EntityDtoMapper entityDtoMapper,

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenService.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenService.java
@@ -3,7 +3,5 @@ package com.knotslicer.server.ports.interactor.services;
 import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
 
 public interface UserWithChildrenService {
-    UserLightDto getWithProjects(Long userId);
-    UserLightDto getWithMembers(Long userId);
-    UserLightDto getWithEvents(Long userId);
+    UserLightDto getUserWithChildren(Long userId);
 }

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenService.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenService.java
@@ -1,0 +1,9 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+
+public interface UserWithChildrenService {
+    UserLightDto getWithProjects(Long userId);
+    UserLightDto getWithMembers(Long userId);
+    UserLightDto getWithEvents(Long userId);
+}

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceImpl.java
@@ -1,0 +1,71 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.Event;
+import com.knotslicer.server.domain.Member;
+import com.knotslicer.server.domain.Project;
+import com.knotslicer.server.domain.User;
+import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.exceptions.EntityNotFoundException;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class UserWithChildrenServiceImpl implements UserWithChildrenService {
+    private EntityDtoMapper entityDtoMapper;
+    private ChildWithOneRequiredParentDao<Project, User> projectDao;
+    private ChildWithTwoParentsDao<Member,User,Project> memberDao;
+    private ChildWithOneRequiredParentDao<Event, User> eventDao;
+    @Override
+    public UserLightDto getWithProjects(Long userId) {
+        Optional<User> optionalUser =
+                projectDao.getPrimaryParentWithChildren(userId);
+        User user = unpackOptionalUser(optionalUser);
+        UserLightDto userLightDto =
+                entityDtoMapper.toLightDto(user);
+        return entityDtoMapper
+                .addProjectDtosToUserLightDto(
+                        userLightDto,
+                        user);
+    }
+    private User unpackOptionalUser(Optional<User> optionalUser) {
+        return optionalUser.orElseThrow(() -> new EntityNotFoundException("User not found."));
+    }
+
+    @Override
+    public UserLightDto getWithMembers(Long userId) {
+        return null;
+    }
+
+    @Override
+    public UserLightDto getWithEvents(Long userId) {
+        Optional<User> optionalUser =
+                eventDao.getPrimaryParentWithChildren(userId);
+        User user = unpackOptionalUser(optionalUser);
+        UserLightDto userLightDto =
+                entityDtoMapper.toLightDto(user);
+        return entityDtoMapper
+                .addEventDtosToUserLightDto(
+                        userLightDto,
+                        user);
+    }
+    @Inject
+    public UserWithChildrenServiceImpl(EntityDtoMapper entityDtoMapper,
+                                       @ProcessAs(ProcessType.PROJECT)
+                                       ChildWithOneRequiredParentDao<Project, User> projectDao,
+                                       @ProcessAs(ProcessType.MEMBER)
+                                           ChildWithTwoParentsDao<Member,User,Project> memberDao,
+                                       @ProcessAs(ProcessType.EVENT)
+                                           ChildWithOneRequiredParentDao<Event, User> eventDao) {
+        this.entityDtoMapper = entityDtoMapper;
+        this.projectDao = projectDao;
+        this.memberDao = memberDao;
+        this.eventDao = eventDao;
+    }
+}

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceImpl.java
@@ -40,6 +40,10 @@ public class UserWithChildrenServiceImpl implements UserWithChildrenService {
 
     @Override
     public UserLightDto getWithMembers(Long userId) {
+        Optional<User> optionalUser = memberDao.getPrimaryParentWithChildren(userId);
+        User user = unpackOptionalUser(optionalUser);
+        UserLightDto userLightDto = entityDtoMapper.toLightDto(user);
+
         return null;
     }
 

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithEventsServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithEventsServiceImpl.java
@@ -1,0 +1,43 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.Event;
+import com.knotslicer.server.domain.User;
+import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.exceptions.EntityNotFoundException;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ProcessAs(ProcessType.EVENT)
+@ApplicationScoped
+public class UserWithEventsServiceImpl implements UserWithChildrenService {
+    private EntityDtoMapper entityDtoMapper;
+    private ChildWithOneRequiredParentDao<Event, User> eventDao;
+    @Override
+    public UserLightDto getUserWithChildren(Long userId) {
+        Optional<User> optionalUser =
+                eventDao.getPrimaryParentWithChildren(userId);
+        User user = unpackOptionalUser(optionalUser);
+        UserLightDto userLightDto =
+                entityDtoMapper.toLightDto(user);
+        return entityDtoMapper
+                .addEventDtosToUserLightDto(
+                        userLightDto,
+                        user);
+    }
+    private User unpackOptionalUser(Optional<User> optionalUser) {
+        return optionalUser.orElseThrow(() -> new EntityNotFoundException("User not found."));
+    }
+    @Inject
+    public UserWithEventsServiceImpl(EntityDtoMapper entityDtoMapper,
+                                     @ProcessAs(ProcessType.EVENT)
+                                     ChildWithOneRequiredParentDao<Event, User> eventDao) {
+        this.entityDtoMapper = entityDtoMapper;
+        this.eventDao = eventDao;
+    }
+}

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithMembersServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithMembersServiceImpl.java
@@ -1,0 +1,43 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.Member;
+import com.knotslicer.server.domain.Project;
+import com.knotslicer.server.domain.User;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
+import com.knotslicer.server.ports.interactor.ProcessAs;
+import com.knotslicer.server.ports.interactor.ProcessType;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.exceptions.EntityNotFoundException;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ProcessAs(ProcessType.MEMBER)
+@ApplicationScoped
+public class UserWithMembersServiceImpl implements UserWithChildrenService {
+    private EntityDtoMapper entityDtoMapper;
+    private ChildWithTwoParentsDao<Member, User, Project> memberDao;
+    @Override
+    public UserLightDto getUserWithChildren(Long userId) {
+        Optional<User> optionalUser = memberDao.getPrimaryParentWithChildren(userId);
+        User user = unpackOptionalUser(optionalUser);
+        UserLightDto userLightDto = entityDtoMapper.toLightDto(user);
+        return entityDtoMapper
+                .addMemberDtosToUserLightDto(
+                        userLightDto,
+                        user);
+    }
+    private User unpackOptionalUser(Optional<User> optionalUser) {
+        return optionalUser.orElseThrow(() -> new EntityNotFoundException("User not found."));
+    }
+    @Inject
+    public UserWithMembersServiceImpl(EntityDtoMapper entityDtoMapper,
+                                      @ProcessAs(ProcessType.MEMBER)
+                                      ChildWithTwoParentsDao<Member,User,Project> memberDao) {
+        this.entityDtoMapper = entityDtoMapper;
+        this.memberDao = memberDao;
+    }
+    protected UserWithMembersServiceImpl() {}
+}

--- a/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithProjectsServiceImpl.java
+++ b/src/main/java/com/knotslicer/server/ports/interactor/services/UserWithProjectsServiceImpl.java
@@ -16,14 +16,13 @@ import jakarta.inject.Inject;
 
 import java.util.Optional;
 
+@ProcessAs(ProcessType.PROJECT)
 @ApplicationScoped
-public class UserWithChildrenServiceImpl implements UserWithChildrenService {
+public class UserWithProjectsServiceImpl implements UserWithChildrenService {
     private EntityDtoMapper entityDtoMapper;
     private ChildWithOneRequiredParentDao<Project, User> projectDao;
-    private ChildWithTwoParentsDao<Member,User,Project> memberDao;
-    private ChildWithOneRequiredParentDao<Event, User> eventDao;
     @Override
-    public UserLightDto getWithProjects(Long userId) {
+    public UserLightDto getUserWithChildren(Long userId) {
         Optional<User> optionalUser =
                 projectDao.getPrimaryParentWithChildren(userId);
         User user = unpackOptionalUser(optionalUser);
@@ -37,39 +36,11 @@ public class UserWithChildrenServiceImpl implements UserWithChildrenService {
     private User unpackOptionalUser(Optional<User> optionalUser) {
         return optionalUser.orElseThrow(() -> new EntityNotFoundException("User not found."));
     }
-
-    @Override
-    public UserLightDto getWithMembers(Long userId) {
-        Optional<User> optionalUser = memberDao.getPrimaryParentWithChildren(userId);
-        User user = unpackOptionalUser(optionalUser);
-        UserLightDto userLightDto = entityDtoMapper.toLightDto(user);
-
-        return null;
-    }
-
-    @Override
-    public UserLightDto getWithEvents(Long userId) {
-        Optional<User> optionalUser =
-                eventDao.getPrimaryParentWithChildren(userId);
-        User user = unpackOptionalUser(optionalUser);
-        UserLightDto userLightDto =
-                entityDtoMapper.toLightDto(user);
-        return entityDtoMapper
-                .addEventDtosToUserLightDto(
-                        userLightDto,
-                        user);
-    }
     @Inject
-    public UserWithChildrenServiceImpl(EntityDtoMapper entityDtoMapper,
+    public UserWithProjectsServiceImpl(EntityDtoMapper entityDtoMapper,
                                        @ProcessAs(ProcessType.PROJECT)
-                                       ChildWithOneRequiredParentDao<Project, User> projectDao,
-                                       @ProcessAs(ProcessType.MEMBER)
-                                           ChildWithTwoParentsDao<Member,User,Project> memberDao,
-                                       @ProcessAs(ProcessType.EVENT)
-                                           ChildWithOneRequiredParentDao<Event, User> eventDao) {
+                                       ChildWithOneRequiredParentDao<Project, User> projectDao) {
         this.entityDtoMapper = entityDtoMapper;
         this.projectDao = projectDao;
-        this.memberDao = memberDao;
-        this.eventDao = eventDao;
     }
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -17,7 +17,7 @@
             <property name="eclipselink.logging.level" value="FINEST"/>
             <property name="eclipselink.logging.level.sql" value="FINE"/>
             <property name="eclipselink.logging.parameters" value="true"/>
-            <!--<property name="eclipselink.cache.shared.default" value="false"/> -->
+            <property name="eclipselink.cache.shared.default" value="false"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -17,6 +17,7 @@
             <property name="eclipselink.logging.level" value="FINEST"/>
             <property name="eclipselink.logging.level.sql" value="FINE"/>
             <property name="eclipselink.logging.parameters" value="true"/>
+            <!--<property name="eclipselink.cache.shared.default" value="false"/> -->
         </properties>
     </persistence-unit>
 </persistence>

--- a/src/test/java/com/knotslicer/server/adapters/rest/EventResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/EventResourceTest.java
@@ -62,20 +62,17 @@ public class EventResourceTest extends JerseyTest {
         Mockito.when(
                 eventService.getWithChildren(anyLong()))
                 .thenReturn(eventDtoDummy);
-
         EventDto eventResponseDto = target("/events/1/polls")
                 .request()
                 .get(EventDto.class);
-        checkEvent(eventResponseDto, eventDtoDummy);
 
+        checkEvent(eventResponseDto, eventDtoDummy);
         List<PollDto> pollResponseDtos =
                 eventResponseDto.getPolls();
-
         PollDto pollResponseDtoOne =
                 pollResponseDtos.get(0);
         checkPolls(pollResponseDtoOne,
                 pollDtoDummyOne.getPollId());
-
         PollDto pollResponseDtoTwo =
                 pollResponseDtos.get(1);
         checkPolls(pollResponseDtoTwo,

--- a/src/test/java/com/knotslicer/server/adapters/rest/EventResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/EventResourceTest.java
@@ -2,8 +2,8 @@ package com.knotslicer.server.adapters.rest;
 
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.EventLinkCreatorImpl;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.EventWithPollsLinkCreatorImpl;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.EventLinkCreator;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.EventWithPollsLinkCreator;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
 import com.knotslicer.server.ports.interactor.datatransferobjects.*;
 import com.knotslicer.server.ports.interactor.services.ParentService;
@@ -33,8 +33,8 @@ public class EventResourceTest extends JerseyTest {
     @Override
     protected Application configure() {
         closeable = MockitoAnnotations.openMocks(this);
-        linkCreator = new EventLinkCreatorImpl();
-        eventWithPollsLinkCreator = new EventWithPollsLinkCreatorImpl();
+        linkCreator = new EventLinkCreator();
+        eventWithPollsLinkCreator = new EventWithPollsLinkCreator();
         linkReceiver = new LinkReceiverImpl();
         return new ResourceConfig()
                 .register(new EventResourceImpl(

--- a/src/test/java/com/knotslicer/server/adapters/rest/PollAnswerResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/PollAnswerResourceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+
 public class PollAnswerResourceTest extends JerseyTest {
     @Mock
     private Service<PollAnswerDto> pollAnswerService;
@@ -100,15 +101,13 @@ public class PollAnswerResourceTest extends JerseyTest {
 
         Mockito.when(pollService.getWithChildren(anyLong()))
                 .thenReturn(pollDtoDummy);
-
         PollDto pollResponseDto = target("/polls/1/pollanswers")
                 .request()
                 .get(PollDto.class);
-        checkPoll(pollResponseDto, pollDtoDummy);
 
+        checkPoll(pollResponseDto, pollDtoDummy);
         List<PollAnswerDto> pollAnswerResponseDtos =
                 pollResponseDto.getPollAnswers();
-
         PollAnswerDto pollAnswerResponseDtoOne =
                 pollAnswerResponseDtos.get(0);
         checkPollAnswer(pollAnswerResponseDtoOne, pollAnswerDtoDummyOne);

--- a/src/test/java/com/knotslicer/server/adapters/rest/PollAnswerResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/PollAnswerResourceTest.java
@@ -4,7 +4,7 @@ package com.knotslicer.server.adapters.rest;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.PollAnswerLinkCreatorImpl;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.PollAnswerLinkCreator;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.PollWithPollAnswersLinkCreator;
 import com.knotslicer.server.ports.interactor.datatransferobjects.*;
 import com.knotslicer.server.ports.interactor.mappers.EntityNotFoundExceptionMapper;
@@ -40,7 +40,7 @@ public class PollAnswerResourceTest extends JerseyTest {
     @Override
     protected Application configure() {
         closeable = MockitoAnnotations.openMocks(this);
-        linkCreator = new PollAnswerLinkCreatorImpl();
+        linkCreator = new PollAnswerLinkCreator();
         pollWithPollAnswersLinkCreator = new PollWithPollAnswersLinkCreator();
         linkReceiver = new LinkReceiverImpl();
         return new ResourceConfig()

--- a/src/test/java/com/knotslicer/server/adapters/rest/ProjectResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/ProjectResourceTest.java
@@ -3,8 +3,8 @@ package com.knotslicer.server.adapters.rest;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ProjectLinkCreatorImpl;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ProjectWithMembersLinkCreatorImpl;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ProjectLinkCreator;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ProjectWithMembersLinkCreator;
 import com.knotslicer.server.ports.interactor.datatransferobjects.*;
 import com.knotslicer.server.ports.interactor.services.ParentService;
 import jakarta.ws.rs.core.Application;
@@ -32,8 +32,8 @@ public class ProjectResourceTest extends JerseyTest {
     @Override
     protected Application configure() {
         closeable = MockitoAnnotations.openMocks(this);
-        linkCreator = new ProjectLinkCreatorImpl();
-        projectWithMembersLinkCreator = new ProjectWithMembersLinkCreatorImpl();
+        linkCreator = new ProjectLinkCreator();
+        projectWithMembersLinkCreator = new ProjectWithMembersLinkCreator();
         linkReceiver = new LinkReceiverImpl();
         return new ResourceConfig()
                 .register(new ProjectResourceImpl(

--- a/src/test/java/com/knotslicer/server/adapters/rest/ProjectResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/ProjectResourceTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 
-
 public class ProjectResourceTest extends JerseyTest {
     @Mock
     private ParentService<ProjectDto> projectService;
@@ -66,15 +65,13 @@ public class ProjectResourceTest extends JerseyTest {
         ProjectDto projectResponseDto = target("/projects/1/members")
                 .request()
                 .get(ProjectDto.class);
-        checkProject(projectResponseDto, projectDtoDummy);
 
+        checkProject(projectResponseDto, projectDtoDummy);
         List<MemberDto> memberResponseDtos =
                 projectResponseDto.getMembers();
-
         MemberDto memberResponseDtoOne =
                 memberResponseDtos.get(0);
         checkMember(memberResponseDtoOne, memberDtoDummyOne);
-
         MemberDto memberResponseDtoTwo =
                 memberResponseDtos.get(1);
         checkMember(memberResponseDtoTwo, memberDtoDummyTwo);

--- a/src/test/java/com/knotslicer/server/adapters/rest/ScheduleResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/ScheduleResourceTest.java
@@ -3,8 +3,8 @@ package com.knotslicer.server.adapters.rest;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.MemberWithSchedulesLinkCreatorImpl;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ScheduleLinkCreatorImpl;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.MemberWithSchedulesLinkCreator;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.ScheduleLinkCreator;
 import com.knotslicer.server.ports.interactor.datatransferobjects.*;
 import com.knotslicer.server.ports.interactor.mappers.EntityNotFoundExceptionMapper;
 import com.knotslicer.server.ports.interactor.services.ParentService;
@@ -39,8 +39,8 @@ public class ScheduleResourceTest extends JerseyTest {
     @Override
     protected Application configure() {
         closeable = MockitoAnnotations.openMocks(this);
-        linkCreator = new ScheduleLinkCreatorImpl();
-        memberWithSchedulesLinkCreator = new MemberWithSchedulesLinkCreatorImpl();
+        linkCreator = new ScheduleLinkCreator();
+        memberWithSchedulesLinkCreator = new MemberWithSchedulesLinkCreator();
         linkReceiver = new LinkReceiverImpl();
         return new ResourceConfig()
                 .register(new ScheduleResourceImpl(

--- a/src/test/java/com/knotslicer/server/adapters/rest/ScheduleResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/ScheduleResourceTest.java
@@ -106,15 +106,13 @@ public class ScheduleResourceTest extends JerseyTest {
         MemberDto memberResponseDto = target("/members/1/schedules")
                 .request()
                 .get(MemberDto.class);
-        checkMember(memberResponseDto, memberDtoDummy);
 
+        checkMember(memberResponseDto, memberDtoDummy);
         List<ScheduleDto> scheduleResponseDtos =
                 memberResponseDto.getSchedules();
-
         ScheduleDto scheduleResponseDtoOne =
                 scheduleResponseDtos.get(0);
         checkSchedule(scheduleResponseDtoOne, scheduleDtoDummyOne);
-
         ScheduleDto scheduleResponseDtoTwo =
                 scheduleResponseDtos.get(1);
         checkSchedule(scheduleResponseDtoTwo, scheduleDtoDummyTwo);

--- a/src/test/java/com/knotslicer/server/adapters/rest/UserWithEventsResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/UserWithEventsResourceTest.java
@@ -3,7 +3,7 @@ package com.knotslicer.server.adapters.rest;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
 import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
 import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
-import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.UserWithProjectsLinkCreator;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.UserWithEventsLinkCreator;
 import com.knotslicer.server.ports.interactor.datatransferobjects.*;
 import com.knotslicer.server.ports.interactor.services.UserWithChildrenService;
 import jakarta.ws.rs.core.Application;
@@ -14,14 +14,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 
-public class UserWithProjectsResourceTest extends JerseyTest {
+public class UserWithEventsResourceTest extends JerseyTest {
     @Mock
     UserWithChildrenService userWithProjectsService;
     private LinkCreator<UserLightDto> linkCreator;
@@ -31,10 +31,10 @@ public class UserWithProjectsResourceTest extends JerseyTest {
     @Override
     protected Application configure() {
         closeable = MockitoAnnotations.openMocks(this);
-        linkCreator = new UserWithProjectsLinkCreator();
+        linkCreator = new UserWithEventsLinkCreator();
         linkReceiver = new LinkReceiverImpl();
         return new ResourceConfig()
-                .register(new UserWithProjectsResource(
+                .register(new UserWithEventsResource(
                         userWithProjectsService,
                         linkCreator,
                         linkReceiver));
@@ -43,33 +43,33 @@ public class UserWithProjectsResourceTest extends JerseyTest {
     public void givenCorrectUserId_whenGetUserWithChildren_thenLinksAreCorrect() {
         UserLightDto userLightDtoDummy = dtoCreator.createUserLightDto();
         userLightDtoDummy.setUserId(1L);
-        ProjectDto projectDtoDummyOne = dtoCreator.createProjectDto();
-        projectDtoDummyOne.setProjectId(1L);
-        ProjectDto projectDtoDummyTwo = dtoCreator.createProjectDto();
-        projectDtoDummyTwo.setProjectId(2L);
-        List<ProjectDto> projectDtos = new LinkedList<>();
-        projectDtos.add(projectDtoDummyOne);
-        projectDtos.add(projectDtoDummyTwo);
-        userLightDtoDummy.setProjects(projectDtos);
+        EventDto eventDtoDummyOne = dtoCreator.createEventDto();
+        eventDtoDummyOne.setEventId(1L);
+        EventDto eventDtoDummyTwo = dtoCreator.createEventDto();
+        eventDtoDummyTwo.setEventId(2L);
+        List<EventDto> eventDtos = new LinkedList<>();
+        eventDtos.add(eventDtoDummyOne);
+        eventDtos.add(eventDtoDummyTwo);
+        userLightDtoDummy.setEvents(eventDtos);
 
         Mockito.when(
-                userWithProjectsService.getUserWithChildren(anyLong()))
+                        userWithProjectsService.getUserWithChildren(anyLong()))
                 .thenReturn(userLightDtoDummy);
-        UserLightDto userResponseDto = target("/users/1/projects")
+        UserLightDto userResponseDto = target("/users/1/events")
                 .request()
                 .get(UserLightDto.class);
 
         checkUser(userResponseDto, userLightDtoDummy);
-        List<ProjectDto> projectResponseDtos =
-                userResponseDto.getProjects();
-        ProjectDto projectResponseDtoOne = projectResponseDtos.get(0);
-        checkProject(projectResponseDtoOne, projectDtoDummyOne);
-        ProjectDto projectResponseDtoTwo = projectResponseDtos.get(1);
-        checkProject(projectResponseDtoTwo, projectDtoDummyTwo);
+        List<EventDto> eventResponseDtos =
+                userResponseDto.getEvents();
+        EventDto eventResponseDtoOne = eventResponseDtos.get(0);
+        checkEvent(eventResponseDtoOne, eventDtoDummyOne);
+        EventDto eventResponseDtoTwo = eventResponseDtos.get(1);
+        checkEvent(eventResponseDtoTwo, eventDtoDummyTwo);
     }
     private void checkUser(UserLightDto userResponseDto, UserLightDto userDtoDummy) {
-        List<Link> userDtoLinks = userResponseDto.getLinks();
-        Link selfLink = userDtoLinks.get(0);
+        List<Link> userResponseDtoLinks = userResponseDto.getLinks();
+        Link selfLink = userResponseDtoLinks.get(0);
         assertEquals("self",
                 selfLink.getRel());
         String userId = userDtoDummy
@@ -81,19 +81,19 @@ public class UserWithProjectsResourceTest extends JerseyTest {
                                 userId),
                 "UserDto's self link is incorrect.");
     }
-    private void checkProject(ProjectDto projectResponseDto, ProjectDto projectDtoDummy) {
-        List<Link> projectDtoLinks = projectResponseDto.getLinks();
-        Link projectLink = projectDtoLinks.get(0);
-        assertEquals("project",
-                projectLink.getRel());
-        String projectId = projectDtoDummy
-                .getProjectId()
+    private void checkEvent(EventDto eventResponseDto, EventDto eventDtoDummy) {
+        List<Link> eventResponseDtoLinks = eventResponseDto.getLinks();
+        Link eventLink = eventResponseDtoLinks.get(0);
+        assertEquals("event",
+                eventLink.getRel());
+        String eventId = eventDtoDummy
+                .getEventId()
                 .toString();
-        assertTrue(projectLink
+        assertTrue(eventLink
                         .getLink()
-                        .contains("/projects/" +
-                                projectId),
-                "ProjectDto's project link is incorrect.");
+                        .contains("/events/" +
+                                eventId),
+                "EventDto's event link is incorrect.");
     }
     @AfterEach
     public void shutdown() throws Exception {

--- a/src/test/java/com/knotslicer/server/adapters/rest/UserWithProjectsResourceTest.java
+++ b/src/test/java/com/knotslicer/server/adapters/rest/UserWithProjectsResourceTest.java
@@ -1,0 +1,106 @@
+package com.knotslicer.server.adapters.rest;
+
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiver;
+import com.knotslicer.server.adapters.rest.linkgenerator.LinkReceiverImpl;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.LinkCreator;
+import com.knotslicer.server.adapters.rest.linkgenerator.linkcreators.UserWithProjectsLinkCreatorImpl;
+import com.knotslicer.server.ports.interactor.datatransferobjects.*;
+import com.knotslicer.server.ports.interactor.services.UserWithChildrenService;
+import jakarta.ws.rs.core.Application;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+public class UserWithProjectsResourceTest extends JerseyTest {
+    @Mock
+    UserWithChildrenService userWithProjectsService;
+    private LinkCreator<UserLightDto> linkCreator;
+    private LinkReceiver linkReceiver;
+    private DtoCreator dtoCreator = new DtoCreatorImpl();
+    private AutoCloseable closeable;
+    @Override
+    protected Application configure() {
+        closeable = MockitoAnnotations.openMocks(this);
+        linkCreator = new UserWithProjectsLinkCreatorImpl();
+        linkReceiver = new LinkReceiverImpl();
+        return new ResourceConfig()
+                .register(new UserWithProjectsResource(
+                        userWithProjectsService,
+                        linkCreator,
+                        linkReceiver));
+    }
+    @Test
+    public void givenCorrectUserId_whenGetUserWithChildren_thenLinksAreCorrect() {
+        UserLightDto userLightDtoDummy = dtoCreator.createUserLightDto();
+        userLightDtoDummy.setUserId(1L);
+        ProjectDto projectDtoDummyOne = dtoCreator.createProjectDto();
+        projectDtoDummyOne.setProjectId(1L);
+        Long userId = userLightDtoDummy.getUserId();
+        projectDtoDummyOne.setUserId(userId);
+        ProjectDto projectDtoDummyTwo = dtoCreator.createProjectDto();
+        projectDtoDummyTwo.setProjectId(2L);
+        projectDtoDummyTwo.setUserId(userId);
+        List<ProjectDto> projectDtos = new LinkedList<>();
+        projectDtos.add(projectDtoDummyOne);
+        projectDtos.add(projectDtoDummyTwo);
+        userLightDtoDummy.setProjects(projectDtos);
+
+        Mockito.when(
+                userWithProjectsService.getUserWithChildren(anyLong()))
+                .thenReturn(userLightDtoDummy);
+
+        UserLightDto userResponseDto = target("/users/1/projects")
+                .request()
+                .get(UserLightDto.class);
+
+        checkUser(userResponseDto, userLightDtoDummy);
+        List<ProjectDto> projectResponseDtos =
+                userResponseDto.getProjects();
+        ProjectDto projectResponseDtoOne = projectResponseDtos.get(0);
+        checkProject(projectResponseDtoOne, projectDtoDummyOne);
+        ProjectDto projectResponseDtoTwo = projectResponseDtos.get(1);
+        checkProject(projectResponseDtoTwo, projectDtoDummyTwo);
+    }
+    private void checkUser(UserLightDto userResponseDto, UserLightDto userDtoDummy) {
+        List<Link> userDtoLinks = userResponseDto.getLinks();
+        Link selfLink = userDtoLinks.get(0);
+        assertEquals("self",
+                selfLink.getRel());
+        String userId = userDtoDummy
+                .getUserId()
+                .toString();
+        assertTrue(selfLink
+                        .getLink()
+                        .contains("/users/" +
+                                userId),
+                "UserDto's self link is incorrect.");
+    }
+    private void checkProject(ProjectDto projectResponseDto, ProjectDto projectDtoDummy) {
+        List<Link> projectDtoLinks = projectResponseDto.getLinks();
+        Link projectLink = projectDtoLinks.get(0);
+        assertEquals("project",
+                projectLink.getRel());
+        String projectId = projectDtoDummy
+                .getProjectId()
+                .toString();
+        assertTrue(projectLink
+                        .getLink()
+                        .contains("/projects/" +
+                                projectId),
+                "ProjectDto's project link is incorrect.");
+    }
+    @AfterEach
+    public void shutdown() throws Exception {
+        closeable.close();
+    }
+}

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
@@ -42,6 +42,8 @@ public class EventServiceTest {
     }
     @Test
     public void givenCorrectEventId_whenGetWithChildren_thenReturnEventDtoWithPollDtos() {
+        User user = entityCreator.createUser();
+        user.setUserId(1L);
         Event event = entityCreator.createEvent();
         event.setEventId(1L);
         event.setEventName("Test Event");
@@ -69,13 +71,15 @@ public class EventServiceTest {
                 pollDao.getPrimaryParentWithChildren(anyLong()))
                 .thenReturn(Optional
                         .of(event));
-        Long userId = 1L;
         Mockito.when(
-                eventDao.getPrimaryParentId(anyLong()))
-                .thenReturn(userId);
+                eventDao.getPrimaryParent(anyLong()))
+                .thenReturn(user);
         EventDto eventDto = eventService.getWithChildren(5L);
 
-        checkEventDto(event, eventDto, userId);
+        checkEventDto(
+                event,
+                eventDto,
+                user.getUserId());
         List<PollDto> pollDtos =
                 eventDto.getPolls();
         PollDto pollDtoOne = pollDtos.get(0);

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
@@ -2,6 +2,7 @@ package com.knotslicer.server.ports.interactor.services;
 
 import com.knotslicer.server.domain.*;
 import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
 import com.knotslicer.server.ports.interactor.EntityCreator;
 import com.knotslicer.server.ports.interactor.EntityCreatorImpl;
 import com.knotslicer.server.ports.interactor.datatransferobjects.DtoCreator;
@@ -29,16 +30,28 @@ public class EventServiceTest {
     private ParentService<EventDto> eventService;
     private EntityCreator entityCreator = new EntityCreatorImpl();
     private DtoCreator dtoCreator = new DtoCreatorImpl();
-    private EntityDtoMapper entityDtoMapper = new EntityDtoMapperImpl(entityCreator, dtoCreator);
+    private EntityDtoMapper entityDtoMapper;
     @Mock
     private ChildWithOneRequiredParentDao<Event, User> eventDao;
     @Mock
     private ChildWithOneRequiredParentDao<Poll, Event> pollDao;
+    @Mock
+    private ChildWithTwoParentsDao<Member,User,Project> memberDao;
+    @Mock
+    private ChildWithTwoParentsDao<PollAnswer, Poll, Member> pollAnswerDao;
     private AutoCloseable closeable;
     @BeforeEach
     public void init() {
         closeable = MockitoAnnotations.openMocks(this);
-        eventService = new EventServiceImpl(entityDtoMapper, eventDao, pollDao);
+        entityDtoMapper = new EntityDtoMapperImpl(
+                entityCreator,
+                dtoCreator,
+                memberDao,
+                pollAnswerDao);
+        eventService = new EventServiceImpl(
+                entityDtoMapper,
+                eventDao,
+                pollDao);
     }
     @Test
     public void givenCorrectEventId_whenGetWithChildren_thenReturnEventDtoWithPollDtos() {

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/EventServiceTest.java
@@ -75,15 +75,15 @@ public class EventServiceTest {
                 .thenReturn(userId);
         EventDto eventDto = eventService.getWithChildren(5L);
 
-        checkEvent(event, eventDto, userId);
+        checkEventDto(event, eventDto, userId);
         List<PollDto> pollDtos =
                 eventDto.getPolls();
         PollDto pollDtoOne = pollDtos.get(0);
-        checkPoll(pollOne, pollDtoOne);
+        checkPollDto(pollOne, pollDtoOne);
         PollDto pollDtoTwo = pollDtos.get(1);
-        checkPoll(pollTwo, pollDtoTwo);
+        checkPollDto(pollTwo, pollDtoTwo);
     }
-    private void checkEvent(Event event, EventDto eventDto, Long userId) {
+    private void checkEventDto(Event event, EventDto eventDto, Long userId) {
         assertEquals(event.getEventId(),
                 eventDto.getEventId());
         assertEquals(event.getEventName(),
@@ -95,7 +95,7 @@ public class EventServiceTest {
         assertEquals(userId,
                 eventDto.getUserId());
     }
-    private void checkPoll(Poll poll, PollDto pollDto) {
+    private void checkPollDto(Poll poll, PollDto pollDto) {
         assertEquals(poll.getPollId(),
                 pollDto.getPollId());
         assertEquals(poll.getStartTimeUtc(),

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
@@ -29,16 +29,26 @@ public class MemberServiceTest {
     private ParentService<MemberDto> memberService;
     private EntityCreator entityCreator = new EntityCreatorImpl();
     private DtoCreator dtoCreator = new DtoCreatorImpl();
-    private EntityDtoMapper entityDtoMapper = new EntityDtoMapperImpl(entityCreator, dtoCreator);
+    private EntityDtoMapper entityDtoMapper;
     @Mock
     private ChildWithTwoParentsDao<Member, User, Project> memberDao;
     @Mock
     private ChildWithOneRequiredParentDao<Schedule, Member> scheduleDao;
+    @Mock
+    private ChildWithTwoParentsDao<PollAnswer, Poll, Member> pollAnswerDao;
     private AutoCloseable closeable;
     @BeforeEach
     public void init() {
         closeable = MockitoAnnotations.openMocks(this);
-        memberService = new MemberServiceImpl(entityDtoMapper, memberDao, scheduleDao);
+        entityDtoMapper = new EntityDtoMapperImpl(
+                entityCreator,
+                dtoCreator,
+                memberDao,
+                pollAnswerDao);
+        memberService = new MemberServiceImpl(
+                entityDtoMapper,
+                memberDao,
+                scheduleDao);
     }
     @Test
     public void givenCorrectMemberId_whenGetWithChildren_thenReturnMemberDtoWithScheduleDtos() {

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
@@ -76,23 +76,21 @@ public class MemberServiceTest {
         Long projectId = 20L;
         Mockito.when(memberDao.getSecondaryParentId(anyLong()))
                 .thenReturn(projectId);
-
         MemberDto memberDto =
                 memberService.getWithChildren(5L);
-        checkMember(member,
+
+        checkMemberDto(member,
                 memberDto,
                 userId,
                 projectId);
-
         List<ScheduleDto> scheduleDtos =
                 memberDto.getSchedules();
         ScheduleDto scheduleDtoOne = scheduleDtos.get(0);
-        checkSchedule(scheduleOne, scheduleDtoOne);
-
+        checkScheduleDto(scheduleOne, scheduleDtoOne);
         ScheduleDto scheduleDtoTwo = scheduleDtos.get(1);
-        checkSchedule(scheduleTwo, scheduleDtoTwo);
+        checkScheduleDto(scheduleTwo, scheduleDtoTwo);
     }
-    private void checkMember(Member member, MemberDto memberDto, Long userId, Long projectId) {
+    private void checkMemberDto(Member member, MemberDto memberDto, Long userId, Long projectId) {
         assertEquals(member.getMemberId(),
                 memberDto.getMemberId());
         assertEquals(member.getName(),
@@ -106,7 +104,7 @@ public class MemberServiceTest {
         assertEquals(projectId,
                 memberDto.getProjectId());
     }
-    private void checkSchedule(Schedule schedule, ScheduleDto scheduleDto) {
+    private void checkScheduleDto(Schedule schedule, ScheduleDto scheduleDto) {
         assertEquals(schedule.getScheduleId(),
                 scheduleDto.getScheduleId());
         assertEquals(schedule.getStartTimeUtc(),

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/MemberServiceTest.java
@@ -42,6 +42,10 @@ public class MemberServiceTest {
     }
     @Test
     public void givenCorrectMemberId_whenGetWithChildren_thenReturnMemberDtoWithScheduleDtos() {
+        User user = entityCreator.createUser();
+        user.setUserId(10L);
+        Project project = entityCreator.createProject();
+        project.setProjectId(20L);
         Member member = entityCreator.createMember();
         member.setMemberId(1L);
         member.setName("member1");
@@ -69,20 +73,18 @@ public class MemberServiceTest {
                 scheduleDao.getPrimaryParentWithChildren(anyLong()))
                 .thenReturn(Optional
                         .of(member));
-        Long userId = 10L;
         Mockito.when(
-                memberDao.getPrimaryParentId(anyLong()))
-                .thenReturn(userId);
-        Long projectId = 20L;
-        Mockito.when(memberDao.getSecondaryParentId(anyLong()))
-                .thenReturn(projectId);
+                memberDao.getPrimaryParent(anyLong()))
+                .thenReturn(user);
+        Mockito.when(memberDao.getSecondaryParent(anyLong()))
+                .thenReturn(project);
         MemberDto memberDto =
                 memberService.getWithChildren(5L);
 
         checkMemberDto(member,
                 memberDto,
-                userId,
-                projectId);
+                user.getUserId(),
+                project.getProjectId());
         List<ScheduleDto> scheduleDtos =
                 memberDto.getSchedules();
         ScheduleDto scheduleDtoOne = scheduleDtos.get(0);

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/PollServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/PollServiceTest.java
@@ -74,18 +74,17 @@ public class PollServiceTest {
         Mockito.when(
                 pollDao.getPrimaryParentId(anyLong()))
                 .thenReturn(eventId);
-
         PollDto pollDto = pollService.getWithChildren(5L);
 
-        checkPoll(poll, pollDto, eventId);
+        checkPollDto(poll, pollDto, eventId);
         List<PollAnswerDto> pollAnswerDtos =
                 pollDto.getPollAnswers();
         PollAnswerDto pollAnswerDtoOne = pollAnswerDtos.get(0);
-        checkPollAnswer(pollAnswerOne, pollAnswerDtoOne);
+        checkPollAnswerDto(pollAnswerOne, pollAnswerDtoOne);
         PollAnswerDto pollAnswerDtoTwo = pollAnswerDtos.get(1);
-        checkPollAnswer(pollAnswerTwo, pollAnswerDtoTwo);
+        checkPollAnswerDto(pollAnswerTwo, pollAnswerDtoTwo);
     }
-    private void checkPoll(Poll poll, PollDto pollDto, Long eventId) {
+    private void checkPollDto(Poll poll, PollDto pollDto, Long eventId) {
         assertEquals(poll.getPollId(),
                 pollDto.getPollId());
         assertEquals(poll.getStartTimeUtc(),
@@ -95,7 +94,7 @@ public class PollServiceTest {
         assertEquals(eventId,
                 pollDto.getEventId());
     }
-    private void checkPollAnswer(PollAnswer pollAnswer, PollAnswerDto pollAnswerDto) {
+    private void checkPollAnswerDto(PollAnswer pollAnswer, PollAnswerDto pollAnswerDto) {
         assertEquals(pollAnswer.getPollAnswerId(),
                 pollAnswerDto.getPollAnswerId());
         assertEquals(pollAnswer.isApproved(),

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/PollServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/PollServiceTest.java
@@ -44,6 +44,8 @@ public class PollServiceTest {
 
     @Test
     public void givenCorrectPollId_whenGetWithChildren_thenReturnPollDtoWithPollAnswerDtos(){
+        Event event = entityCreator.createEvent();
+        event.setEventId(1L);
         Poll poll = entityCreator.createPoll();
         poll.setPollId(1L);
         poll.setStartTimeUtc(
@@ -70,13 +72,15 @@ public class PollServiceTest {
                 pollAnswerDao.getPrimaryParentWithChildren(anyLong()))
                 .thenReturn(Optional
                         .of(poll));
-        Long eventId = 1L;
         Mockito.when(
-                pollDao.getPrimaryParentId(anyLong()))
-                .thenReturn(eventId);
+                pollDao.getPrimaryParent(anyLong()))
+                .thenReturn(event);
         PollDto pollDto = pollService.getWithChildren(5L);
 
-        checkPollDto(poll, pollDto, eventId);
+        checkPollDto(
+                poll,
+                pollDto,
+                event.getEventId());
         List<PollAnswerDto> pollAnswerDtos =
                 pollDto.getPollAnswers();
         PollAnswerDto pollAnswerDtoOne = pollAnswerDtos.get(0);

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
@@ -73,20 +73,19 @@ public class ProjectServiceTest {
         Mockito.when(
                 projectDao.getPrimaryParentId(anyLong()))
                 .thenReturn(userId);
-
         ProjectDto projectDto =
                 projectService.getWithChildren(7L);
-        checkProject(project, projectDto, userId);
 
+        checkProjectDto(project, projectDto, userId);
         List<MemberDto> memberDtos =
                 projectDto.getMembers();
         MemberDto memberDtoOne = memberDtos.get(0);
-        checkMember(memberOne, memberDtoOne);
+        checkMemberDto(memberOne, memberDtoOne);
 
         MemberDto memberDtoTwo = memberDtos.get(1);
-        checkMember(memberTwo, memberDtoTwo);
+        checkMemberDto(memberTwo, memberDtoTwo);
     }
-    private void checkProject(Project project, ProjectDto projectDto, Long userId) {
+    private void checkProjectDto(Project project, ProjectDto projectDto, Long userId) {
         assertEquals(project.getProjectId(),
                 projectDto.getProjectId());
         assertEquals(project.getProjectName(),
@@ -96,7 +95,7 @@ public class ProjectServiceTest {
         assertEquals(userId,
                 projectDto.getUserId());
     }
-    private void checkMember(Member member, MemberDto memberDto) {
+    private void checkMemberDto(Member member, MemberDto memberDto) {
         assertEquals(member.getMemberId(),
                 memberDto.getMemberId());
         assertEquals(member.getName(),

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
@@ -27,27 +27,39 @@ public class ProjectServiceTest {
     private ParentService<ProjectDto> projectService;
     private EntityCreator entityCreator = new EntityCreatorImpl();
     private DtoCreator dtoCreator = new DtoCreatorImpl();
-    private EntityDtoMapper entityDtoMapper = new EntityDtoMapperImpl(entityCreator, dtoCreator);
+    private EntityDtoMapper entityDtoMapper;
     @Mock
     private ChildWithOneRequiredParentDao<Project, User> projectDao;
     @Mock
     private ChildWithTwoParentsDao<Member,User,Project> memberDao;
+    @Mock
+    private ChildWithTwoParentsDao<PollAnswer, Poll, Member> pollAnswerDao;
     private AutoCloseable closeable;
 
     @BeforeEach
     public void init() {
         closeable = MockitoAnnotations.openMocks(this);
-        projectService = new ProjectServiceImpl(entityDtoMapper, projectDao, memberDao);
+        entityDtoMapper = new EntityDtoMapperImpl(
+                entityCreator,
+                dtoCreator,
+                memberDao,
+                pollAnswerDao);
+        projectService = new ProjectServiceImpl(
+                entityDtoMapper,
+                projectDao,
+                memberDao);
     }
     @Test
     public void givenCorrectProjectId_whenGetWithChildren_thenReturnProjectDtoWithMemberDtos() {
-        User user = entityCreator.createUser();
-        user.setUserId(25L);
+        User parentUser = entityCreator.createUser();
+        parentUser.setUserId(25L);
         Project project = entityCreator.createProject();
         project.setProjectId(1L);
         project.setProjectName("project1");
         project.setProjectDescription("project1 description");
         ProjectImpl projectImpl = (ProjectImpl) project;
+        User userOne = entityCreator.createUser();
+        userOne.setUserId(1L);
         Member memberOne = entityCreator.createMember();
         memberOne.setMemberId(1L);
         memberOne.setName("member1");
@@ -57,6 +69,8 @@ public class ProjectServiceTest {
         UserImpl userImpl1 = (UserImpl) entityCreator.createUser();
         userImpl1.addMember(memberImpl1);
         projectImpl.addMember(memberImpl1);
+        User userTwo = entityCreator.createUser();
+        userTwo.setUserId(2L);
         Member memberTwo = entityCreator.createMember();
         memberTwo.setMemberId(2L);
         memberTwo.setName("member2");
@@ -73,21 +87,38 @@ public class ProjectServiceTest {
                         .of(project));
         Mockito.when(
                 projectDao.getPrimaryParent(anyLong()))
-                .thenReturn(user);
+                .thenReturn(parentUser);
+        Mockito.when(
+                memberDao.getPrimaryParent(
+                        memberOne.getMemberId()))
+                .thenReturn(userOne);
+        Mockito.when(
+                memberDao.getPrimaryParent(
+                        memberTwo.getMemberId()))
+                .thenReturn(userTwo);
         ProjectDto projectDto =
                 projectService.getWithChildren(7L);
 
+        Long parentUserId = parentUser.getUserId();
         checkProjectDto(
                 project,
                 projectDto,
-                user.getUserId());
+                parentUserId);
         List<MemberDto> memberDtos =
                 projectDto.getMembers();
         MemberDto memberDtoOne = memberDtos.get(0);
-        checkMemberDto(memberOne, memberDtoOne);
+        Long userOneId = userOne.getUserId();
+        checkMemberDto(
+                memberOne,
+                memberDtoOne,
+                userOneId);
 
         MemberDto memberDtoTwo = memberDtos.get(1);
-        checkMemberDto(memberTwo, memberDtoTwo);
+        Long userTwoId = userTwo.getUserId();
+        checkMemberDto(
+                memberTwo,
+                memberDtoTwo,
+                userTwoId);
     }
     private void checkProjectDto(Project project, ProjectDto projectDto, Long userId) {
         assertEquals(project.getProjectId(),
@@ -99,9 +130,11 @@ public class ProjectServiceTest {
         assertEquals(userId,
                 projectDto.getUserId());
     }
-    private void checkMemberDto(Member member, MemberDto memberDto) {
+    private void checkMemberDto(Member member, MemberDto memberDto, Long userId) {
         assertEquals(member.getMemberId(),
                 memberDto.getMemberId());
+        assertEquals(userId,
+                memberDto.getUserId());
         assertEquals(member.getName(),
                 memberDto.getName());
         assertEquals(member.getRole(),

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/ProjectServiceTest.java
@@ -41,6 +41,8 @@ public class ProjectServiceTest {
     }
     @Test
     public void givenCorrectProjectId_whenGetWithChildren_thenReturnProjectDtoWithMemberDtos() {
+        User user = entityCreator.createUser();
+        user.setUserId(25L);
         Project project = entityCreator.createProject();
         project.setProjectId(1L);
         project.setProjectName("project1");
@@ -69,14 +71,16 @@ public class ProjectServiceTest {
                 memberDao.getSecondaryParentWithChildren(anyLong()))
                 .thenReturn(Optional
                         .of(project));
-        Long userId = 25L;
         Mockito.when(
-                projectDao.getPrimaryParentId(anyLong()))
-                .thenReturn(userId);
+                projectDao.getPrimaryParent(anyLong()))
+                .thenReturn(user);
         ProjectDto projectDto =
                 projectService.getWithChildren(7L);
 
-        checkProjectDto(project, projectDto, userId);
+        checkProjectDto(
+                project,
+                projectDto,
+                user.getUserId());
         List<MemberDto> memberDtos =
                 projectDto.getMembers();
         MemberDto memberDtoOne = memberDtos.get(0);

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithChildrenServiceTest.java
@@ -1,0 +1,147 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.*;
+import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
+import com.knotslicer.server.ports.interactor.EntityCreator;
+import com.knotslicer.server.ports.interactor.EntityCreatorImpl;
+import com.knotslicer.server.ports.interactor.datatransferobjects.*;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapperImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+public class UserWithChildrenServiceTest {
+
+    private UserWithChildrenService userWithChildrenService;
+    private EntityCreator entityCreator = new EntityCreatorImpl();
+    private DtoCreator dtoCreator = new DtoCreatorImpl();
+    private EntityDtoMapper entityDtoMapper = new EntityDtoMapperImpl(entityCreator, dtoCreator);
+    @Mock
+    private ChildWithOneRequiredParentDao<Project, User> projectDao;
+    @Mock
+    private ChildWithTwoParentsDao<Member,User,Project> memberDao;
+    @Mock
+    private ChildWithOneRequiredParentDao<Event, User> eventDao;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void init() {
+        closeable = MockitoAnnotations.openMocks(this);
+        userWithChildrenService = new UserWithChildrenServiceImpl(
+                entityDtoMapper,
+                projectDao,
+                memberDao,
+                eventDao);
+    }
+    @Test
+    public void givenCorrectUserId_whenGetWithProjects_thenReturnUserLightDtoWithProjectDtos() {
+        User user = createTestUser();
+        Project projectOne = entityCreator.createProject();
+        projectOne.setProjectId(1L);
+        projectOne.setProjectName("Project One Name");
+        projectOne.setProjectDescription("Project One Description");
+        UserImpl userImpl = (UserImpl) user;
+        ProjectImpl projectOneImpl = (ProjectImpl) projectOne;
+        userImpl.addProject(projectOneImpl);
+        Project projectTwo = entityCreator.createProject();
+        projectTwo.setProjectId(2L);
+        projectTwo.setProjectName("Project Two Name");
+        projectTwo.setProjectDescription("Project Two Description");
+        ProjectImpl projectTwoImpl = (ProjectImpl) projectTwo;
+        userImpl.addProject(projectTwoImpl);
+
+        Mockito.when(
+                projectDao.getPrimaryParentWithChildren(anyLong()))
+                .thenReturn(
+                        Optional.of(user));
+        Long userId = user.getUserId();
+        UserLightDto userLightDto =
+                userWithChildrenService.getWithProjects(userId);
+
+        checkUserLightDto(user, userLightDto);
+        List<ProjectDto> projectDtos = userLightDto.getProjects();
+        ProjectDto projectDtoOne = projectDtos.get(0);
+        checkProjectDto(projectOne, projectDtoOne);
+        ProjectDto projectDtoTwo = projectDtos.get(1);
+        checkProjectDto(projectTwo, projectDtoTwo);
+    }
+    private User createTestUser() {
+        User user = entityCreator.createUser();
+        user.setUserId(1L);
+        user.setEmail("example@mail.com");
+        user.setUserName("testUser");
+        user.setUserDescription("Test User Description");
+        user.setTimeZone(
+                ZoneId.of("America/Los_Angeles"));
+        return user;
+    }
+    private void checkUserLightDto(User user, UserLightDto userLightDto) {
+        assertEquals(user.getUserId(), userLightDto.getUserId());
+        assertEquals(user.getUserName(), userLightDto.getUserName());
+        assertEquals(user.getUserDescription(), userLightDto.getUserDescription());
+        assertEquals(user.getTimeZone(), userLightDto.getTimeZone());
+    }
+    private void checkProjectDto(Project project, ProjectDto projectDto) {
+        assertEquals(project.getProjectId(), projectDto.getProjectId());
+        assertEquals(project.getProjectName(), projectDto.getProjectName());
+        assertEquals(project.getProjectDescription(), projectDto.getProjectDescription());
+    }
+    @Test
+    public void givenCorrectUserId_whenGetWithEvents_thenReturnUserLightDtoWithEventDtos() {
+        User user = createTestUser();
+        Event eventOne = entityCreator.createEvent();
+        eventOne.setEventId(1L);
+        eventOne.setEventName("EventOne Name");
+        eventOne.setSubject("EventOne Subject");
+        eventOne.setEventDescription("EventOne Description");
+        UserImpl userImpl = (UserImpl) user;
+        EventImpl eventImplOne = (EventImpl) eventOne;
+        userImpl.addEvent(eventImplOne);
+        Event eventTwo = entityCreator.createEvent();
+        eventTwo.setEventId(2L);
+        eventTwo.setEventName("EventTwo Name");
+        eventTwo.setSubject("EventTwo Subject");
+        eventTwo.setEventDescription("EventTwo Description");
+        EventImpl eventImplTwo = (EventImpl) eventTwo;
+        userImpl.addEvent(eventImplTwo);
+
+        Mockito.when(eventDao.getPrimaryParentWithChildren(anyLong()))
+                .thenReturn(
+                        Optional.of(user));
+        Long userId = user.getUserId();
+        UserLightDto userLightDto =
+                userWithChildrenService.getWithEvents(userId);
+
+        checkUserLightDto(user, userLightDto);
+        List<EventDto> eventDtos = userLightDto.getEvents();
+        EventDto eventDtoOne = eventDtos.get(0);
+        checkEventDto(eventOne, eventDtoOne);
+        EventDto eventDtoTwo = eventDtos.get(1);
+        checkEventDto(eventTwo, eventDtoTwo);
+    }
+    private void checkEventDto(Event event, EventDto eventDto) {
+        assertEquals(event.getEventId(),
+                eventDto.getEventId());
+        assertEquals(event.getEventName(),
+                eventDto.getEventName());
+        assertEquals(event.getSubject(),
+                eventDto.getSubject());
+        assertEquals(event.getEventDescription(),
+                eventDto.getEventDescription());
+    }
+    @AfterEach
+    public void shutdown() throws Exception {
+        closeable.close();
+    }
+}

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithMembersServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithMembersServiceTest.java
@@ -1,0 +1,126 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.*;
+import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
+import com.knotslicer.server.ports.interactor.EntityCreator;
+import com.knotslicer.server.ports.interactor.EntityCreatorImpl;
+import com.knotslicer.server.ports.interactor.datatransferobjects.DtoCreator;
+import com.knotslicer.server.ports.interactor.datatransferobjects.DtoCreatorImpl;
+import com.knotslicer.server.ports.interactor.datatransferobjects.MemberDto;
+import com.knotslicer.server.ports.interactor.datatransferobjects.UserLightDto;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapperImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+public class UserWithMembersServiceTest {
+    private UserWithChildrenService userWithMembersService;
+    private EntityCreator entityCreator = new EntityCreatorImpl();
+    private DtoCreator dtoCreator = new DtoCreatorImpl();
+    private EntityDtoMapper entityDtoMapper;
+    @Mock
+    private ChildWithTwoParentsDao<Member,User, Project> memberDao;
+    @Mock
+    private ChildWithTwoParentsDao<PollAnswer, Poll, Member> pollAnswerDao;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void init() {
+        closeable = MockitoAnnotations.openMocks(this);
+        entityDtoMapper = new EntityDtoMapperImpl(
+                entityCreator,
+                dtoCreator,
+                memberDao,
+                pollAnswerDao);
+        userWithMembersService = new UserWithMembersServiceImpl(
+                entityDtoMapper,
+                memberDao);
+    }
+    @Test
+    public void givenCorrectUserId_whenGetUserWithChildren_thenReturnUserLightDtoWithMemberDtos() {
+        User user = entityCreator.createUser();
+        user.setUserId(1L);
+        user.setEmail("example@mail.com");
+        user.setUserName("testUser");
+        user.setUserDescription("Test User Description");
+        user.setTimeZone(
+                ZoneId.of("America/Los_Angeles"));
+        Project projectOne = entityCreator.createProject();
+        projectOne.setProjectId(1L);
+        Member memberOne = entityCreator.createMember();
+        memberOne.setMemberId(1L);
+        memberOne.setName("MemberOne Name");
+        memberOne.setRole("MemberOne Role");
+        memberOne.setRoleDescription("MemberOne Role Description");
+        UserImpl userImpl = (UserImpl) user;
+        MemberImpl memberOneImpl = (MemberImpl) memberOne;
+        userImpl.addMember(memberOneImpl);
+        Project projectTwo = entityCreator.createProject();
+        projectTwo.setProjectId(2L);
+        Member memberTwo = entityCreator.createMember();
+        memberTwo.setMemberId(2L);
+        memberTwo.setName("MemberTwo Name");
+        memberTwo.setRole("MemberTwo Role");
+        memberTwo.setRoleDescription("MemberTwo Role Description");
+        MemberImpl memberTwoImpl = (MemberImpl) memberTwo;
+        userImpl.addMember(memberTwoImpl);
+
+        Mockito.when(
+                memberDao.getPrimaryParentWithChildren(anyLong()))
+                .thenReturn(Optional.of(user));
+        Mockito.when(
+                memberDao.getSecondaryParent(
+                        memberOne.getMemberId()))
+                .thenReturn(projectOne);
+        Mockito.when(
+                memberDao.getSecondaryParent(
+                        memberTwo.getMemberId()))
+                .thenReturn(projectTwo);
+        Long userId = user.getUserId();
+        UserLightDto userLightDto = userWithMembersService.getUserWithChildren(userId);
+
+        checkUserLightDto(user, userLightDto);
+        List<MemberDto> memberDtos = userLightDto.getMembers();
+        MemberDto memberDtoOne = memberDtos.get(0);
+        Long projectOneId = projectOne.getProjectId();
+        checkMemberDto(
+                memberOne,
+                memberDtoOne,
+                projectOneId);
+        MemberDto memberDtoTwo = memberDtos.get(1);
+        Long projectTwoId = projectTwo.getProjectId();
+        checkMemberDto(
+                memberTwo,
+                memberDtoTwo,
+                projectTwoId);
+    }
+    private void checkUserLightDto(User user, UserLightDto userLightDto) {
+        assertEquals(user.getUserId(), userLightDto.getUserId());
+        assertEquals(user.getUserName(), userLightDto.getUserName());
+        assertEquals(user.getUserDescription(), userLightDto.getUserDescription());
+        assertEquals(user.getTimeZone(), userLightDto.getTimeZone());
+    }
+    private void checkMemberDto(Member member, MemberDto memberDto, Long projectId) {
+        assertEquals(member.getMemberId(), memberDto.getMemberId());
+        assertEquals(projectId, memberDto.getProjectId());
+        assertEquals(member.getName(), memberDto.getName());
+        assertEquals(member.getRole(), memberDto.getRole());
+        assertEquals(member.getRoleDescription(), memberDto.getRoleDescription());
+    }
+    @AfterEach
+    public void shutdown() throws Exception {
+        closeable.close();
+    }
+}

--- a/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithProjectsServiceTest.java
+++ b/src/test/java/com/knotslicer/server/ports/interactor/services/UserWithProjectsServiceTest.java
@@ -1,0 +1,104 @@
+package com.knotslicer.server.ports.interactor.services;
+
+import com.knotslicer.server.domain.*;
+import com.knotslicer.server.ports.entitygateway.ChildWithOneRequiredParentDao;
+import com.knotslicer.server.ports.entitygateway.ChildWithTwoParentsDao;
+import com.knotslicer.server.ports.interactor.EntityCreator;
+import com.knotslicer.server.ports.interactor.EntityCreatorImpl;
+import com.knotslicer.server.ports.interactor.datatransferobjects.*;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapper;
+import com.knotslicer.server.ports.interactor.mappers.EntityDtoMapperImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+public class UserWithProjectsServiceTest {
+
+    private UserWithChildrenService userWithProjectsService;
+    private EntityCreator entityCreator = new EntityCreatorImpl();
+    private DtoCreator dtoCreator = new DtoCreatorImpl();
+    private EntityDtoMapper entityDtoMapper;
+    @Mock
+    private ChildWithOneRequiredParentDao<Project, User> projectDao;
+    @Mock
+    private ChildWithTwoParentsDao<Member,User,Project> memberDao;
+    @Mock
+    private ChildWithTwoParentsDao<PollAnswer, Poll, Member> pollAnswerDao;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void init() {
+        closeable = MockitoAnnotations.openMocks(this);
+        entityDtoMapper = new EntityDtoMapperImpl(
+                entityCreator,
+                dtoCreator,
+                memberDao,
+                pollAnswerDao);
+        userWithProjectsService = new UserWithProjectsServiceImpl(
+                entityDtoMapper,
+                projectDao);
+    }
+    @Test
+    public void givenCorrectUserId_whenGetUserWithChildren_thenReturnUserLightDtoWithProjectDtos() {
+        User user = entityCreator.createUser();
+        user.setUserId(1L);
+        user.setEmail("example@mail.com");
+        user.setUserName("testUser");
+        user.setUserDescription("Test User Description");
+        user.setTimeZone(
+                ZoneId.of("America/Los_Angeles"));
+        Project projectOne = entityCreator.createProject();
+        projectOne.setProjectId(1L);
+        projectOne.setProjectName("Project One Name");
+        projectOne.setProjectDescription("Project One Description");
+        UserImpl userImpl = (UserImpl) user;
+        ProjectImpl projectOneImpl = (ProjectImpl) projectOne;
+        userImpl.addProject(projectOneImpl);
+        Project projectTwo = entityCreator.createProject();
+        projectTwo.setProjectId(2L);
+        projectTwo.setProjectName("Project Two Name");
+        projectTwo.setProjectDescription("Project Two Description");
+        ProjectImpl projectTwoImpl = (ProjectImpl) projectTwo;
+        userImpl.addProject(projectTwoImpl);
+
+        Mockito.when(
+                projectDao.getPrimaryParentWithChildren(anyLong()))
+                .thenReturn(
+                        Optional.of(user));
+        Long userId = user.getUserId();
+        UserLightDto userLightDto =
+                userWithProjectsService.getUserWithChildren(userId);
+
+        checkUserLightDto(user, userLightDto);
+        List<ProjectDto> projectDtos = userLightDto.getProjects();
+        ProjectDto projectDtoOne = projectDtos.get(0);
+        checkProjectDto(projectOne, projectDtoOne);
+        ProjectDto projectDtoTwo = projectDtos.get(1);
+        checkProjectDto(projectTwo, projectDtoTwo);
+    }
+    private void checkUserLightDto(User user, UserLightDto userLightDto) {
+        assertEquals(user.getUserId(), userLightDto.getUserId());
+        assertEquals(user.getUserName(), userLightDto.getUserName());
+        assertEquals(user.getUserDescription(), userLightDto.getUserDescription());
+        assertEquals(user.getTimeZone(), userLightDto.getTimeZone());
+    }
+    private void checkProjectDto(Project project, ProjectDto projectDto) {
+        assertEquals(project.getProjectId(), projectDto.getProjectId());
+        assertEquals(project.getProjectName(), projectDto.getProjectName());
+        assertEquals(project.getProjectDescription(), projectDto.getProjectDescription());
+    }
+
+    @AfterEach
+    public void shutdown() throws Exception {
+        closeable.close();
+    }
+}


### PR DESCRIPTION
Rest endpoints for getting a user with any type of child are working as expected. LinkCreator's names were simplified. User has multiple resource files to simplify each class. 

Creating a DTO whose corresponding entity had two parents, involved fetching the secondary parent using EclipseLink to create the corresponding links. Initially, this was done implicitly by lazy loading the secondary parent of the detached entities in the EntityDtoMapper. This could unfortunately lead to coupling to EclipseLink. To avoid using EclipseLink specific features, EntityDtoMapper explicitly uses two Dao classes to fetch an entity's secondary parent.